### PR TITLE
DEP-600 read only file system (except tmp dir required by spring boot)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @ktech-org/ktech-developer-platform

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,0 +1,36 @@
+repository:
+  description: Library of common helm charts for use with bandstand
+  topics: helm, kubernetes, bandstand
+  has_issues: false
+  has_wiki: false
+  has_downloads: false
+  default_branch: main
+  delete_branch_on_merge: true
+  allow_squash_merge: true
+  allow_merge_commit: false
+  allow_rebase_merge: false
+  enable_vulnerability_alerts: true
+  enable_automated_security_fixes: true
+
+teams:
+  - name: ktech-developer-platform
+    permission: admin
+
+branches:
+  - name: main
+    protection:
+      required_pull_request_reviews:
+        required_approving_review_count: 1
+        dismiss_stale_reviews: true
+        require_code_owner_reviews: true
+        dismissal_restrictions:
+          users: []
+          teams: []
+      required_status_checks:
+        strict: true
+        contexts: []
+      enforce_admins: true
+      restrictions:
+        apps: []
+        users: []
+        teams: []

--- a/charts/service-library/templates/_deployment.yaml
+++ b/charts/service-library/templates/_deployment.yaml
@@ -22,6 +22,9 @@ spec:
             - name: http
               containerPort: 8080
           volumeMounts:
+            - name: tmp-dir
+              mountPath: /tmp
+              readOnly: false
             - name: config
               mountPath: "/etc/{{ .Release.Name }}/config"
               readOnly: true
@@ -47,6 +50,13 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
+          securityContext:
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - all
       volumes:
         - name: config
           configMap:
@@ -54,4 +64,8 @@ spec:
             items:
               - key: "app.properties"
                 path: "app.properties"
+        - name: tmp-dir
+          emptyDir: {}
+      securityContext:
+        runAsUser: 1000
 {{- end -}}


### PR DESCRIPTION
Tighten up security of the service library chart
- read only files system (except tmp dir required for spring boot)
- don't run as root
- remove all linux capabilities
- prevent privilege escalation