### PR TITLE
Remove test pod from service label selector.

### DIFF
--- a/charts/bandstand-web-service/Chart.yaml
+++ b/charts/bandstand-web-service/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bandstand-web-service
-version: 1.2.3
+version: 1.2.4
 description: Library chart of templates for an http service
 type: library
 maintainers:

--- a/charts/bandstand-web-service/templates/tests/_pod.yaml
+++ b/charts/bandstand-web-service/templates/tests/_pod.yaml
@@ -3,7 +3,11 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: {{ .Release.Name }}-acceptance-tests
-  labels: {{- include "bandstand-web-service.labels" . | nindent 4 }}
+  labels:
+    application-under-test: {{ .Release.Name }}
+    version: {{ .Values.image.tag }}
+    environment: {{ .Values.env }}
+    owner: {{ .Values.owner }}
   annotations:
     "helm.sh/hook": test
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded


### PR DESCRIPTION
Service is picking up `application` label in test pod so acceptance tests often fail as they end up calling their own pod.