### PR TITLE
Add open telemetry settings to tracing.

### DIFF
--- a/charts/bandstand-web-service/Chart.yaml
+++ b/charts/bandstand-web-service/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bandstand-web-service
-version: 1.3.0
+version: 1.3.1
 description: Library chart of templates for an http service
 type: library
 maintainers:

--- a/charts/bandstand-web-service/templates/_deployment.yaml
+++ b/charts/bandstand-web-service/templates/_deployment.yaml
@@ -74,6 +74,12 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
+            - name: OTEL_SERVICE_NAME
+              value: {{ .Release.Name }}
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: http://collector.linkerd-jaeger:4317
+            - name: OTEL_PROPAGATORS
+              value: b3multi
             {{- if .Values.additionalEnvVars }}
               {{- toYaml .Values.additionalEnvVars | nindent 12 }}
             {{- end }}


### PR DESCRIPTION
Adding OTEL settings in chart means that templates only need to add OTEL client to get tracing out of the box.