### PR TITLE
Fix/allow backofflimit of 0

### DIFF
--- a/charts/bandstand-cron-job/Chart.yaml
+++ b/charts/bandstand-cron-job/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bandstand-cron-job
-version: 1.3.1
+version: 1.3.2
 description: Library chart of templates for a simple cron job
 type: library
 maintainers:

--- a/charts/bandstand-cron-job/templates/_cronjob.yaml
+++ b/charts/bandstand-cron-job/templates/_cronjob.yaml
@@ -14,7 +14,9 @@ spec:
             "linkerd.io/inject": disabled
         spec:
           serviceAccountName: {{ .Release.Name }}
-          backoffLimit: {{ .Values.backoffLimit | default 6 }}
+          {{- if hasKey .Values "backoffLimit" }}
+          backoffLimit: {{ .Values.backoffLimit | indent 10 }}
+          {{- end }}
           concurrencyPolicy: {{ .Values.concurrencyPolicy | default "Allow" }}
           restartPolicy: {{ .Values.restartPolicy | default "OnFailure" }}
           containers:

--- a/charts/bandstand-cron-job/templates/_cronjob.yaml
+++ b/charts/bandstand-cron-job/templates/_cronjob.yaml
@@ -15,7 +15,7 @@ spec:
         spec:
           serviceAccountName: {{ .Release.Name }}
           {{- if hasKey .Values "backoffLimit" }}
-          backoffLimit: {{ .Values.backoffLimit | indent 10 }}
+          backoffLimit: {{ .Values.backoffLimit }}
           {{- end }}
           concurrencyPolicy: {{ .Values.concurrencyPolicy | default "Allow" }}
           restartPolicy: {{ .Values.restartPolicy | default "OnFailure" }}


### PR DESCRIPTION
Currently when backoffLimit is set to 0 the logic sees it as false and renders the default value. With this fix when the value is not set it falls back to the cron-job default, which is 6 (same as the default we previously set)