### PR TITLE
Don't cleanup test pods on success as breaks log retrieval

### DIFF
--- a/charts/bandstand-web-service/Chart.yaml
+++ b/charts/bandstand-web-service/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bandstand-web-service
-version: 1.5.2
+version: 1.6.0
 description: Library chart of templates for an http service
 type: library
 maintainers:

--- a/charts/bandstand-web-service/templates/tests/_pod.yaml
+++ b/charts/bandstand-web-service/templates/tests/_pod.yaml
@@ -15,7 +15,7 @@ metadata:
     owner: {{ .Values.owner }}
   annotations:
     "helm.sh/hook": test
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-delete-policy": before-hook-creation
     "polaris.fairwinds.com/readinessProbeMissing-exempt": "true"
     "polaris.fairwinds.com/livenessProbeMissing-exempt": "true"
     "linkerd.io/inject": disabled


### PR DESCRIPTION
Don't cleanup helm test pods on success. Required to avoid build breaks as a result of https://github.com/ktech-org/circleci-orb-bandstand/pull/11
