### PR TITLE
Make mount paths consistent for test/non-test pods

### DIFF
--- a/charts/bandstand-test-runner/Chart.yaml
+++ b/charts/bandstand-test-runner/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bandstand-test-runner
-version: 1.1.2
+version: 1.1.3
 description: Library for running standalone test containers
 type: library
 maintainers:

--- a/charts/bandstand-test-runner/templates/tests/_pods.yaml
+++ b/charts/bandstand-test-runner/templates/tests/_pods.yaml
@@ -64,8 +64,12 @@ spec:
         {{- toYaml $testRun.env | nindent 8 }}
         {{- end }}
       volumeMounts:
-        - name: workspace
-          mountPath: /tmp/workspace
+        - name: tmp
+          mountPath: /tmp
+          readOnly: false
+        - name: tmp
+          mountPath: /tmp/workspace # explicitly add workspace dir for backwards compatibility
+          subPath: workspace
           readOnly: false
       securityContext:
         runAsNonRoot: true
@@ -75,7 +79,7 @@ spec:
           drop:
             - all
   volumes:
-    - name: workspace
+    - name: tmp
       emptyDir: { }
   securityContext:
     runAsUser: 1000

--- a/charts/bandstand-web-service/Chart.yaml
+++ b/charts/bandstand-web-service/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bandstand-web-service
-version: 1.6.0
+version: 1.6.1
 description: Library chart of templates for an http service
 type: library
 maintainers:

--- a/charts/bandstand-web-service/templates/tests/_pod.yaml
+++ b/charts/bandstand-web-service/templates/tests/_pod.yaml
@@ -45,8 +45,12 @@ spec:
         - name: ENV
           value: {{ .Values.env }}
       volumeMounts:
-        - name: workspace
-          mountPath: /tmp/workspace
+        - name: tmp
+          mountPath: /tmp
+          readOnly: false
+        - name: tmp
+          mountPath: /tmp/workspace # explicitly add workspace dir for backwards compatibility
+          subPath: workspace
           readOnly: false
       securityContext:
         runAsNonRoot: true
@@ -56,7 +60,7 @@ spec:
           drop:
             - all
   volumes:
-    - name: workspace
+    - name: tmp
       emptyDir: { }
   securityContext:
     runAsUser: 1000


### PR DESCRIPTION
Enable write access to /tmp in test pods, currently just /tmp/workspace which is inconsistent with other pods. Note this PR keeps an explicit /tmp/workspace mount for backwards compatibility