### PR TITLE
Increase header max size on ingress, enable response buffering

### DIFF
--- a/charts/bandstand-web-service/templates/ingress.yaml
+++ b/charts/bandstand-web-service/templates/ingress.yaml
@@ -11,6 +11,8 @@ metadata:
   annotations:
     bandstand.ktech.com/service-visibility: {{ .Values.ingress.visibility }}
     nginx.ingress.kubernetes.io/service-upstream: "true"
+    nginx.ingress.kubernetes.io/proxy-buffering: "on"
+    nginx.ingress.kubernetes.io/proxy-buffer-size: "16k"
     nginx.ingress.kubernetes.io/large-client-header-buffers: "4 16k"
     {{- with .Values.ingress.annotations }}
       {{- toYaml . | nindent 4 }}

--- a/charts/bandstand-web-service/templates/ingress.yaml
+++ b/charts/bandstand-web-service/templates/ingress.yaml
@@ -11,6 +11,7 @@ metadata:
   annotations:
     bandstand.ktech.com/service-visibility: {{ .Values.ingress.visibility }}
     nginx.ingress.kubernetes.io/service-upstream: "true"
+    nginx.ingress.kubernetes.io/large-client-header-buffers: "4 16k"
     {{- with .Values.ingress.annotations }}
       {{- toYaml . | nindent 4 }}
     {{- end }}


### PR DESCRIPTION
To allow large `Cookie` headers to be sent from the client browser and `Set-Cookie` headers to be sent from the server. Most web services will have authentication and so large auth tokens will be used in most cases, both sent from the client and from the server for validating the user session and refreshing the session.

Explanation of proxy buffering: https://www.digitalocean.com/community/tutorials/understanding-nginx-http-proxying-load-balancing-buffering-and-caching#using-buffers-to-free-up-backend-servers

Additional context for `large-client-header-buffers`:
* https://github.com/ktech-org/cognito-login-ui/pull/187
* https://github.com/ktech-org/cognito-login-ui/pull/189
* Nginx Ingress https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/#large-client-header-buffers
* Node.js https://nodejs.org/dist/latest-v18.x/docs/api/all.html#all_cli_--max-http-header-sizesize

Google suggests that the max size for Java Spring Boot is the same as Node.js (8KiB)