### PR TITLE
Fix large_client_header_buffers nginx directive

### DIFF
--- a/charts/bandstand-web-service/Chart.yaml
+++ b/charts/bandstand-web-service/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bandstand-web-service
-version: 3.3.2
+version: 3.3.3
 description: Application chart for a web service
 type: application
 maintainers:

--- a/charts/bandstand-web-service/templates/ingress.yaml
+++ b/charts/bandstand-web-service/templates/ingress.yaml
@@ -13,7 +13,8 @@ metadata:
     nginx.ingress.kubernetes.io/service-upstream: "true"
     nginx.ingress.kubernetes.io/proxy-buffering: "on"
     nginx.ingress.kubernetes.io/proxy-buffer-size: "16k"
-    nginx.ingress.kubernetes.io/large-client-header-buffers: "4 16k"
+    nginx.ingress.kubernetes.io/server-snippet: |
+      large_client_header_buffers 4 16k;
     {{- with .Values.ingress.annotations }}
       {{- toYaml . | nindent 4 }}
     {{- end }}


### PR DESCRIPTION
Fix for `large_client_header_buffers` nginx directive by using `server-snippet`.

I suspect the reason why this didn't work is because bandstand-services is using an outdated version of ingress-nginx controller. Can @ktech-org/ktech-developer-platform ticket and prioritise the work to upgrade?

Please also advise whether you would prefer this configuration to be in `bandstand-charts` or `bandstand-services`, @paul-ktech suggested these annotations could go in either repo.