### PR TITLE
Fix: use 'nameSuffix' in ingress backend service name

### DIFF
--- a/charts/bandstand-web-service/Chart.yaml
+++ b/charts/bandstand-web-service/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bandstand-web-service
-version: 3.6.1
+version: 3.6.2
 description: Application chart for a web service
 type: application
 maintainers:

--- a/charts/bandstand-web-service/templates/ingress.yaml
+++ b/charts/bandstand-web-service/templates/ingress.yaml
@@ -34,7 +34,7 @@ spec:
             pathType: Prefix
             backend:
               service:
-                name: {{ default .Release.Name .Values.ingress.defaultBackend }}
+                name: {{ default $relName .Values.ingress.defaultBackend }}
                 port:
                   number: 80
           {{- if .Values.ingress.additionalPaths }}


### PR DESCRIPTION
Current behaviour is to ignore the name suffix for the backend service name. Using the name suffix makes adding a second deployment more intuitive as it will use the backend name which matches the ingress host name.

Here's a search for the places where `nameSuffix` is being used: https://github.com/search?q=org%3Aktech-org+nameSuffix+language%3AYAML&type=code&l=YAML&p=1

This should not be a breaking change for any existing services:

* [labelling-triage-svc](https://github.com/ktech-org/labelling-triage-svc/blob/17025b8df14af6f9720336770e864b48ea6b5f45/chart/values.yaml#L28) - this ingress already has `defaultBackend` so this is not a breaking change
* [experiences-ping](https://github.com/ktech-org/experiences-ping/blob/5c32095220a13b1bd42cded35fe2f552371a822c/chart/values.yaml#L26) - this does not have an ingress on the chart with `nameSuffix`
* [amra-user-management](https://github.com/ktech-org/amra-user-management/blob/0d625601920308d9e0d3c1e29246b3b63e931e0c/chart/values.yaml#L29) - same as previous