### PR TITLE
Allow setting runAsUser and FsGroup

### DIFF
--- a/charts/bandstand-cron-job/Chart.yaml
+++ b/charts/bandstand-cron-job/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bandstand-cron-job
-version: 3.5.1
+version: 3.6.0
 description: Application chart for a simple cron job
 type: application
 maintainers:

--- a/charts/bandstand-cron-job/templates/_helpers.tpl
+++ b/charts/bandstand-cron-job/templates/_helpers.tpl
@@ -24,8 +24,8 @@ capabilities:
 {{- end -}}
 
 {{- define "bandstand-cron-job.podSecurityContext" -}}
-runAsUser: 1000
-fsGroup: 1000
+runAsUser: {{ .Values.runAsUser | default 1000  }}
+fsGroup: {{ .Values.fsGroup | default 1000  }}
 {{- end -}}
 
 {{- define "bandstand-cron-job.common-volumes" -}}


### PR DESCRIPTION
Allow setting runAsUser and FsGroup so that I can get psql working for the cloudquery cron job. The PSQL container used in this has a user and group set to 70:70. 