### PR TITLE
Replace special characters in secret keys with underscores

### DIFF
--- a/charts/bandstand-cron-job/Chart.yaml
+++ b/charts/bandstand-cron-job/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bandstand-cron-job
-version: 4.0.0
+version: 4.0.1
 description: Application chart for a simple cron job
 type: application
 maintainers:

--- a/charts/bandstand-cron-job/templates/extsecrets.yaml
+++ b/charts/bandstand-cron-job/templates/extsecrets.yaml
@@ -15,5 +15,9 @@ spec:
   dataFrom:
     - extract:
         key: {{ .secret }}
+      rewrite:
+        - regexp:
+            source: "[^a-zA-Z0-9]"
+            target: "_"
 ---
 {{- end }}

--- a/charts/bandstand-headless-service/Chart.yaml
+++ b/charts/bandstand-headless-service/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bandstand-headless-service
-version: 3.0.0
+version: 3.0.1
 description: Chart for a standalone (non-web) service
 type: application
 maintainers:

--- a/charts/bandstand-headless-service/templates/extsecrets.yaml
+++ b/charts/bandstand-headless-service/templates/extsecrets.yaml
@@ -15,5 +15,9 @@ spec:
   dataFrom:
     - extract:
         key: {{ .secret }}
+      rewrite:
+        - regexp:
+            source: "[^a-zA-Z0-9]"
+            target: "_"
 ---
 {{- end }}

--- a/charts/bandstand-web-service/Chart.yaml
+++ b/charts/bandstand-web-service/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bandstand-web-service
-version: 4.0.0
+version: 4.0.1
 description: Application chart for a web service
 type: application
 maintainers:

--- a/charts/bandstand-web-service/templates/extsecrets.yaml
+++ b/charts/bandstand-web-service/templates/extsecrets.yaml
@@ -15,5 +15,9 @@ spec:
   dataFrom:
     - extract:
         key: {{ .secret }}
+      rewrite:
+        - regexp:
+            source: "[^a-zA-Z0-9]"
+            target: "_"
 ---
 {{- end }}


### PR DESCRIPTION
Help channel issue - dashes aren't valid in env vars, but we've got dashes in the shared confluent secret keys. This means that they don't work properly if you use the new external secrets chart feature. This change maps all special characters in keys to underscores so they are valid envvar keys