### PR TITLE
Add seccompProfile to triggered jobs

### DIFF
--- a/charts/bandstand-triggered-job/Chart.yaml
+++ b/charts/bandstand-triggered-job/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bandstand-triggered-job
-version: 1.0.2
+version: 1.0.3
 description: Application chart for a job triggered from SQS
 type: application
 maintainers:

--- a/charts/bandstand-triggered-job/templates/_helpers.tpl
+++ b/charts/bandstand-triggered-job/templates/_helpers.tpl
@@ -21,6 +21,8 @@ readOnlyRootFilesystem: true
 capabilities:
   drop:
     - all
+seccompProfile:
+  type: RuntimeDefault
 {{- end -}}
 
 {{- define "bandstand-triggered-job.podSecurityContext" -}}


### PR DESCRIPTION
Spotted this got missed because of the timing between adding the triggered job chart and fixing the warning