### PR TITLE
Add External Secrets to triggered job

### DIFF
--- a/charts/bandstand-triggered-job/Chart.yaml
+++ b/charts/bandstand-triggered-job/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bandstand-triggered-job
-version: 1.0.4
+version: 1.1.0
 description: Application chart for a job triggered from SQS
 type: application
 maintainers:

--- a/charts/bandstand-triggered-job/templates/extsecrets.yaml
+++ b/charts/bandstand-triggered-job/templates/extsecrets.yaml
@@ -1,0 +1,23 @@
+{{- range .Values.secrets }}
+{{- $secretHash := sha256sum .secret | substr 0 6 }}
+{{- $secretName := list $.Release.Name $.Values.nameSuffix .name $secretHash | join "-" }}
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: {{ $secretName }}
+  annotations:
+    force-sync: '{{ now | unixEpoch }}'
+spec:
+  secretStoreRef:
+    name: cluster-store
+    kind: ClusterSecretStore
+  target: {}
+  dataFrom:
+    - extract:
+        key: {{ .secret }}
+      rewrite:
+        - regexp:
+            source: "[^a-zA-Z0-9]"
+            target: "_"
+---
+{{- end }}

--- a/charts/bandstand-triggered-job/templates/scaledjob.yaml
+++ b/charts/bandstand-triggered-job/templates/scaledjob.yaml
@@ -73,6 +73,17 @@ spec:
             {{- if .Values.envFrom }}
             envFrom:
               {{- .Values.envFrom | toYaml | trimPrefix "|" | trimPrefix "\n" | nindent 16 }}
+              {{- range .Values.secrets }}
+              {{- $secretHash := sha256sum .secret | substr 0 6 }}
+              {{- $secretName := list $.Release.Name $.Values.nameSuffix .name $secretHash | join "-" }}
+              - secretRef:
+                  name: {{ $secretName }}
+                  optional: {{ .optional | default false }}
+                {{- if .prefix }}
+                prefix: {{ .prefix }}
+                {{- end }}
+              {{- end }}
+              {{- end }}
             {{- end }}
             securityContext: {{- include "bandstand-triggered-job.containerSecurityContext" . | nindent 16 }}
         imagePullSecrets:

--- a/charts/bandstand-triggered-job/templates/scaledjob.yaml
+++ b/charts/bandstand-triggered-job/templates/scaledjob.yaml
@@ -78,12 +78,12 @@ spec:
             {{- range .Values.secrets }}
             {{- $secretHash := sha256sum .secret | substr 0 6 }}
             {{- $secretName := list $.Release.Name $.Values.nameSuffix .name $secretHash | join "-" }}
-            - secretRef:
-                name: {{ $secretName }}
-                optional: {{ .optional | default false }}
-              {{- if .prefix }}
-              prefix: {{ .prefix }}
-              {{- end }}
+              - secretRef:
+                  name: {{ $secretName }}
+                  optional: {{ .optional | default false }}
+                {{- if .prefix }}
+                prefix: {{ .prefix }}
+               {{- end }}
             {{- end }}
             {{- end }}
             securityContext: {{- include "bandstand-triggered-job.containerSecurityContext" . | nindent 16 }}

--- a/charts/bandstand-triggered-job/templates/scaledjob.yaml
+++ b/charts/bandstand-triggered-job/templates/scaledjob.yaml
@@ -73,7 +73,7 @@ spec:
             {{- if or (.Values.envFrom) (.Values.secrets) }}
             envFrom:
             {{- if .Values.envFrom }}
-            {{- .Values.envFrom | toYaml | trimPrefix "|" | trimPrefix "\n" | nindent 16 }}
+            {{- .Values.envFrom | toYaml | trimPrefix "|" | trimPrefix "\n" | nindent 14 }}
             {{- end }}
             {{- range .Values.secrets }}
             {{- $secretHash := sha256sum .secret | substr 0 6 }}

--- a/charts/bandstand-triggered-job/templates/scaledjob.yaml
+++ b/charts/bandstand-triggered-job/templates/scaledjob.yaml
@@ -72,7 +72,9 @@ spec:
               {{- end }}
             {{- if or (.Values.envFrom) (.Values.secrets) }}
             envFrom:
+            {{- if .Values.envFrom }}
             {{- .Values.envFrom | toYaml | trimPrefix "|" | trimPrefix "\n" | nindent 16 }}
+            {{- end }}
             {{- range .Values.secrets }}
             {{- $secretHash := sha256sum .secret | substr 0 6 }}
             {{- $secretName := list $.Release.Name $.Values.nameSuffix .name $secretHash | join "-" }}

--- a/charts/bandstand-triggered-job/templates/scaledjob.yaml
+++ b/charts/bandstand-triggered-job/templates/scaledjob.yaml
@@ -70,7 +70,7 @@ spec:
               {{- if .Values.environmentEnvVars }}
               {{- .Values.environmentEnvVars | toYaml | trimPrefix "|" | trimPrefix "\n" | nindent 16 }}
               {{- end }}
-            {{- if .Values.envFrom }}
+            {{- if or (.Values.envFrom) (.Values.secrets) }}
             envFrom:
               {{- .Values.envFrom | toYaml | trimPrefix "|" | trimPrefix "\n" | nindent 16 }}
               {{- range .Values.secrets }}
@@ -82,7 +82,6 @@ spec:
                 {{- if .prefix }}
                 prefix: {{ .prefix }}
                 {{- end }}
-              {{- end }}
               {{- end }}
             {{- end }}
             securityContext: {{- include "bandstand-triggered-job.containerSecurityContext" . | nindent 16 }}

--- a/charts/bandstand-triggered-job/templates/scaledjob.yaml
+++ b/charts/bandstand-triggered-job/templates/scaledjob.yaml
@@ -72,17 +72,17 @@ spec:
               {{- end }}
             {{- if or (.Values.envFrom) (.Values.secrets) }}
             envFrom:
-              {{- .Values.envFrom | toYaml | trimPrefix "|" | trimPrefix "\n" | nindent 16 }}
-              {{- range .Values.secrets }}
-              {{- $secretHash := sha256sum .secret | substr 0 6 }}
-              {{- $secretName := list $.Release.Name $.Values.nameSuffix .name $secretHash | join "-" }}
-              - secretRef:
-                  name: {{ $secretName }}
-                  optional: {{ .optional | default false }}
-                {{- if .prefix }}
-                prefix: {{ .prefix }}
-                {{- end }}
+            {{- .Values.envFrom | toYaml | trimPrefix "|" | trimPrefix "\n" | nindent 16 }}
+            {{- range .Values.secrets }}
+            {{- $secretHash := sha256sum .secret | substr 0 6 }}
+            {{- $secretName := list $.Release.Name $.Values.nameSuffix .name $secretHash | join "-" }}
+            - secretRef:
+                name: {{ $secretName }}
+                optional: {{ .optional | default false }}
+              {{- if .prefix }}
+              prefix: {{ .prefix }}
               {{- end }}
+            {{- end }}
             {{- end }}
             securityContext: {{- include "bandstand-triggered-job.containerSecurityContext" . | nindent 16 }}
         imagePullSecrets:

--- a/test-charts/triggered-job/secrets/values.yaml
+++ b/test-charts/triggered-job/secrets/values.yaml
@@ -10,3 +10,7 @@ bandstand-triggered-job:
       optional: true
     - name: my-second-secret
       secret: my-other-secret-name
+
+  envFrom:
+    - configMapRef:
+        name: shared-config-map


### PR DESCRIPTION
Should have been there from the outset but it got missed because the PoC must have been created before the ext secrets integration. Should fix Boris's issue in the help channel