### PR TITLE
DEP-1978: Increase certificate duration and renewBefore

### DIFF
--- a/charts/bandstand-web-service/Chart.yaml
+++ b/charts/bandstand-web-service/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bandstand-web-service
-version: 4.3.1
+version: 4.3.2
 description: Application chart for a web service
 type: application
 maintainers:

--- a/charts/bandstand-web-service/templates/certificate.yaml
+++ b/charts/bandstand-web-service/templates/certificate.yaml
@@ -11,12 +11,12 @@ spec:
   commonName: {{ . }}
   dnsNames:
     - "*.{{ . }}"
-  duration: 24h
+  duration: 720h
   issuerRef:
     group: awspca.cert-manager.io
     kind: AWSPCAClusterIssuer
     name: cluster-issuer
-  renewBefore: 2h
+  renewBefore: 24h
   secretName: additional-domain-cert
   usages:
     - server auth


### PR DESCRIPTION
### Changes Made 

The following changes have been made to bandstand-charts and ingress-nginx

- I have changed the spec.duration from 24 hours to 720 hours (i.e. 30 days). 

- I have changed the spec.renewBefore from 2 hours to 24 hours. 

I have not made any changes to **gc-keda-consumer** although this project also has duration: 24h and renewBefore: 2h at present. 


### Documentation

(1) AWS - Managing the private CA lifecycle: [Choosing validity periods ](https://docs.aws.amazon.com/privateca/latest/userguide/ca-lifecycle.html#ca-validity-period)

> The default validity period for an end-entity certificate issued through ACM is 13 months (395 days)


(2) cert-manager/certificate: [issuance triggers](https://cert-manager.io/docs/usage/certificate/#issuance-triggers)

> cert-manager will automatically renew Certificates. It will calculate when to renew a Certificate based on the issued X.509 certificate's duration and a 'renewBefore' value which specifies how long before expiry a certificate should be renewed.
> 
> spec.duration and spec.renewBefore fields on a Certificate can be used to specify an X.509 certificate's duration and a 'renewBefore' value. Default value for spec.duration is 90 days.