### PR TITLE
DEP-1978: Increase certificate duration and renewBefore

### DIFF
--- a/charts/bandstand-web-service/Chart.yaml
+++ b/charts/bandstand-web-service/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bandstand-web-service
-version: 4.3.2
+version: 4.3.3
 description: Application chart for a web service
 type: application
 maintainers:

--- a/charts/bandstand-web-service/templates/certificate.yaml
+++ b/charts/bandstand-web-service/templates/certificate.yaml
@@ -11,12 +11,12 @@ spec:
   commonName: {{ . }}
   dnsNames:
     - "*.{{ . }}"
-  duration: 720h
+  duration: 2160h
   issuerRef:
     group: awspca.cert-manager.io
     kind: AWSPCAClusterIssuer
     name: cluster-issuer
-  renewBefore: 24h
+  renewBefore: 360h
   secretName: additional-domain-cert
   usages:
     - server auth


### PR DESCRIPTION
## Description

- Increase certificate duration to 2160 hours (90 days)
- Increase certificate renewBefore to 360 hours (15 days)