### PR TITLE
Propagate job labels down to pods

### DIFF
--- a/charts/bandstand-cron-job/Chart.yaml
+++ b/charts/bandstand-cron-job/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bandstand-cron-job
-version: 4.1.1
+version: 4.1.2
 description: Application chart for a simple cron job
 type: application
 maintainers:

--- a/charts/bandstand-cron-job/templates/cronjob.yaml
+++ b/charts/bandstand-cron-job/templates/cronjob.yaml
@@ -17,6 +17,7 @@ spec:
         metadata:
           annotations:
             "linkerd.io/inject": disabled
+          labels: {{- include "bandstand-cron-job.labels" . | nindent 12 }}
         spec:
           serviceAccountName: {{ .Release.Name }}
           restartPolicy: {{ .Values.restartPolicy | default "OnFailure" }}

--- a/charts/bandstand-job/Chart.yaml
+++ b/charts/bandstand-job/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bandstand-job
-version: 1.1.1
+version: 1.1.2
 description: Application chart for a simple job starting immediately after deployment
 type: application
 maintainers:

--- a/charts/bandstand-job/templates/job.yaml
+++ b/charts/bandstand-job/templates/job.yaml
@@ -10,6 +10,7 @@ spec:
     metadata:
       annotations:
         "linkerd.io/inject": disabled
+      labels: {{- include "bandstand-job.labels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ .Release.Name }}
       restartPolicy: {{ .Values.restartPolicy | default "OnFailure" }}

--- a/charts/bandstand-triggered-job/Chart.yaml
+++ b/charts/bandstand-triggered-job/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bandstand-triggered-job
-version: 1.2.1
+version: 1.2.2
 description: Application chart for a job triggered from SQS
 type: application
 maintainers:

--- a/charts/bandstand-triggered-job/templates/scaledjob.yaml
+++ b/charts/bandstand-triggered-job/templates/scaledjob.yaml
@@ -4,6 +4,8 @@ metadata:
   name: {{ .Release.Name }}
   labels: {{- include "bandstand-triggered-job.labels" . | nindent 4 }}
 spec:
+  successfulJobsHistoryLimit: 30
+  failedJobsHistoryLimit: 50
   jobTargetRef:
     parallelism: 1                            # [max number of desired pods](https://kubernetes.io/docs/concepts/workloads/controllers/job/#controlling-parallelism)
     completions: 1                            # [desired number of successfully finished pods](https://kubernetes.io/docs/concepts/workloads/controllers/job/#controlling-parallelism)
@@ -15,6 +17,7 @@ spec:
       metadata:
         annotations:
           "linkerd.io/inject": disabled
+        labels: {{- include "bandstand-triggered-job.labels" . | nindent 10 }}
       spec:
         serviceAccountName: {{ .Release.Name }}
         restartPolicy: {{ .Values.restartPolicy | default "OnFailure" }}


### PR DESCRIPTION
The various flavours of Job weren't propagating labels (e.g. application, owner, version) down to the underlying pods like they should. This fixes that.

Also reduce the default job retention for the SQS triggered job from 100 to 30 (50 for failures). This is mainly to reduce the pressure on the clusters from bad SQS jobs that aren't consuming messages properly (like the CP job in amra-test).