### PR TITLE
DEP-2114 Fix issue with defining multiple connectors

### DIFF
--- a/charts/bandstand-confluent-connect/Chart.yaml
+++ b/charts/bandstand-confluent-connect/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bandstand-confluent-connect
-version: 1.2.0
+version: 1.2.1
 description: Chart for deploying confluent connect clusters and connectors
 type: application
 sources:

--- a/charts/bandstand-confluent-connect/templates/connectors.yaml
+++ b/charts/bandstand-confluent-connect/templates/connectors.yaml
@@ -16,4 +16,5 @@ spec:
   {{- $config := merge $.Values.commonConnectorConfig (.config | default dict ) }}
   configs:
     {{- tpl ($config | toYaml) $ | nindent 4 }}
+---
 {{- end }}


### PR DESCRIPTION
The yaml produced for multiple confluent connectors omitted the yaml object divider.