### PR TITLE
Dep 2296 update confluent connect annotation pt2

### DIFF
--- a/charts/bandstand-confluent-connect/Chart.yaml
+++ b/charts/bandstand-confluent-connect/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bandstand-confluent-connect
-version: 1.2.3
+version: 1.2.4
 description: Chart for deploying confluent connect clusters and connectors
 type: application
 sources:

--- a/charts/bandstand-confluent-connect/templates/connect.yaml
+++ b/charts/bandstand-confluent-connect/templates/connect.yaml
@@ -32,15 +32,24 @@ spec:
             "init_config": {
               "is_jmx": true,
               "collect_default_metrics": false
+              "conf": {
+                "include": {
+                  "confluent.kafka.connect.source_task.source_record_write_total"
+                  "confluent.kafka.connect.worker.connector_total_task_count"
+                  "confluent.kafka.connect.worker.connector_running_task_count"
+                  "confluent.kafka.connect.source_task.source_record_write_rate"
+                  "confluent.kafka.connect.worker.connector_count"
+                  "confluent.kafka.connect.connector_metrics.status"
+                  "confluent.kafka.connect.connect_metrics.outgoing_byte_rate"
+                  "confluent.kafka.connect.source_task.source_record_poll_total"
+                  "confluent.kafka.connect.source_task.source_record_poll_rate"
+                  "confluent.kafka.connect.connect_metrics.incoming_byte_rate"
+                }
+              }
             },
             "instances": [{
               "host": "%%host%%",
               "port": "7203",
-              "conf": {
-                "include": [
-                  "confluent.kafka.connect.*"
-                ]
-              }
             }]
           }
         }

--- a/charts/bandstand-confluent-connect/templates/connect.yaml
+++ b/charts/bandstand-confluent-connect/templates/connect.yaml
@@ -34,15 +34,15 @@ spec:
               "collect_default_metrics": false
               "conf": {
                 "include": {
-                  "confluent.kafka.connect.source_task.source_record_write_total"
-                  "confluent.kafka.connect.worker.connector_total_task_count"
-                  "confluent.kafka.connect.worker.connector_running_task_count"
-                  "confluent.kafka.connect.source_task.source_record_write_rate"
-                  "confluent.kafka.connect.worker.connector_count"
-                  "confluent.kafka.connect.connector_metrics.status"
-                  "confluent.kafka.connect.connect_metrics.outgoing_byte_rate"
-                  "confluent.kafka.connect.source_task.source_record_poll_total"
-                  "confluent.kafka.connect.source_task.source_record_poll_rate"
+                  "confluent.kafka.connect.source_task.source_record_write_total",
+                  "confluent.kafka.connect.worker.connector_total_task_count",
+                  "confluent.kafka.connect.worker.connector_running_task_count",
+                  "confluent.kafka.connect.source_task.source_record_write_rate",
+                  "confluent.kafka.connect.worker.connector_count",
+                  "confluent.kafka.connect.connector_metrics.status",
+                  "confluent.kafka.connect.connect_metrics.outgoing_byte_rate",
+                  "confluent.kafka.connect.source_task.source_record_poll_total",
+                  "confluent.kafka.connect.source_task.source_record_poll_rate",
                   "confluent.kafka.connect.connect_metrics.incoming_byte_rate"
                 }
               }

--- a/charts/bandstand-confluent-connect/templates/connect.yaml
+++ b/charts/bandstand-confluent-connect/templates/connect.yaml
@@ -26,30 +26,153 @@ spec:
         {{- end }}
   podTemplate:
     annotations:
-      ad.datadoghq.com/{{ $relName }}.checks: |
+      ad.datadoghq.com/royid-connect-svc.checks: |
         {
           "confluent_platform": {
             "init_config": {
               "is_jmx": true,
-              "collect_default_metrics": false
-              "conf": {
-                "include": {
-                  "confluent.kafka.connect.source_task.source_record_write_total",
-                  "confluent.kafka.connect.worker.connector_total_task_count",
-                  "confluent.kafka.connect.worker.connector_running_task_count",
-                  "confluent.kafka.connect.source_task.source_record_write_rate",
-                  "confluent.kafka.connect.worker.connector_count",
-                  "confluent.kafka.connect.connector_metrics.status",
-                  "confluent.kafka.connect.connect_metrics.outgoing_byte_rate",
-                  "confluent.kafka.connect.source_task.source_record_poll_total",
-                  "confluent.kafka.connect.source_task.source_record_poll_rate",
-                  "confluent.kafka.connect.connect_metrics.incoming_byte_rate"
+              "collect_default_metrics": false,
+              "conf": [
+                {
+                  "include": {
+                    "domain": "kafka.connect",
+                    "type": "connector-task-metrics",
+                    "bean_regex": "kafka.connect:type=connector-task-metrics,connector=.*,task=.*",
+                    "attribute": {
+                      "status": {
+                        "metric_type": "gauge",
+                        "alias": "confluent.kafka.connect.connector_metrics.status",
+                        "values": {
+                          "running": 0,
+                          "paused": 1,
+                          "failed": 2,
+                          "destroyed": 3,
+                          "unassigned": -1
+                        }
+                      }
+                    }
+                  }
+                },
+                {
+                  "include": {
+                    "domain": "kafka.connect",
+                    "type": "connect-worker-metrics",
+                    "bean_regex": "kafka.connect:type=connect-worker-metrics,connector=.*",
+                    "attribute": {
+                      "connector-total-task-count": {
+                        "metric_type": "gauge",
+                        "alias": "confluent.kafka.connect.worker.connector-total-task-count"
+                      }
+                    }
+                  }
+                },
+                {
+                  "include": {
+                    "domain": "kafka.connect",
+                    "type": "connect-worker-metrics",
+                    "bean_regex": "kafka.connect:type=connect-worker-metrics,connector=.*",
+                    "attribute": {
+                      "connector-running-task-count": {
+                        "metric_type": "gauge",
+                        "alias": "confluent.kafka.connect.worker.connector-running-task-count"
+                      }
+                    }
+                  }
+                },
+                {
+                  "include": {
+                    "domain": "kafka.connect",
+                    "type": "connect-worker-metrics",
+                    "bean": "kafka.connect:type=connect-worker-metrics",
+                    "attribute": {
+                      "connector-count": {
+                        "metric_type": "gauge",
+                        "alias": "confluent.kafka.connect.worker.connector-count"
+                      }
+                    }
+                  }
+                },
+                {
+                  "include": {
+                    "domain": "kafka.connect",
+                    "type": "connect-metrics",
+                    "bean_regex": "kafka.connect:type=connect-metrics,client-id=.*",
+                    "attribute": {
+                      "incoming_byte_rate": {
+                        "alias": "confluent.kafka.connect.connect_metrics.incoming_byte_rate"
+                      }
+                    }
+                  }
+                },
+                {
+                  "include": {
+                    "domain": "kafka.connect",
+                    "type": "connect-metrics",
+                    "bean_regex": "kafka.connect:type=connect-metrics,client-id=.*",
+                    "attribute": {
+                      "outgoing-byte-rate": {
+                        "alias": "confluent.kafka.connect.connect_metrics.outgoing_byte_rate"
+                      }
+                    }
+                  }
+                },
+                {
+                  "include": {
+                    "domain": "kafka.connect",
+                    "type": "source-task-metrics",
+                    "bean_regex": "kafka.connect:type=source-task-metrics,connector=.*,task=.*",
+                    "attribute": {
+                      "source-record-write-total": {
+                        "metric_type": "gauge",
+                        "alias": "confluent.kafka.connect.source_task.source-record-write-total"
+                      }
+                    }
+                  }
+                },
+                {
+                  "include": {
+                    "domain": "kafka.connect",
+                    "type": "source-task-metrics",
+                    "bean_regex": "kafka.connect:type=source-task-metrics,connector=.*,task=.*",
+                    "attribute": {
+                      "source-record-write-rate": {
+                        "metric_type": "gauge",
+                        "alias": "confluent.kafka.connect.source_task.source-record-write-rate"
+                      }
+                    }
+                  }
+                },
+                {
+                  "include": {
+                    "domain": "kafka.connect",
+                    "type": "source-task-metrics",
+                    "bean_regex": "kafka.connect:type=source-task-metrics,connector=.*,task=.*",
+                    "attribute": {
+                      "source-record-poll-total": {
+                        "metric_type": "gauge",
+                        "alias": "confluent.kafka.connect.source_task.source-record-poll-total"
+                      }
+                    }
+                  }
+                },
+                {
+                  "include": {
+                    "domain": "kafka.connect",
+                    "type": "source-task-metrics",
+                    "bean_regex": "kafka.connect:type=source-task-metrics,connector=.*,task=.*",
+                    "attribute": {
+                      "source-record-poll-rate": {
+                        "metric_type": "gauge",
+                        "alias": "confluent.kafka.connect.source_task.source-record-poll-rate"
+                      }
+                    }
+                  }
                 }
-              }
+              ]
             },
             "instances": [{
               "host": "%%host%%",
-              "port": "7203",
+              "port": "7203"
             }]
           }
         }


### PR DESCRIPTION
Updated config, currently tested on the royid-connect-svc pod and I'm only able to see the following metrics:

1. Connector Status
2. Connector - Total Tasks Count
3. Connector - Total Running Tasks
4. Connector Worker Count

To be investigated further but wanted to place my changes here safely for now.

Further to this, there hasn’t been much activity over the last few days on prod, so extending the timespan gives more data for the metrics.  Will check with Pavel once he is back from leave.