### PR TITLE
NOJIRA Add startup probe

### DIFF
--- a/charts/bandstand-web-service/Chart.yaml
+++ b/charts/bandstand-web-service/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bandstand-web-service
-version: 4.9.4
+version: 4.9.5
 description: Application chart for a web service
 type: application
 maintainers:

--- a/charts/bandstand-web-service/templates/deployment.yaml
+++ b/charts/bandstand-web-service/templates/deployment.yaml
@@ -85,16 +85,22 @@ spec:
             httpGet:
               path: {{ (.Values.livenessProbe).path | default "/" }}
               port: http
-            initialDelaySeconds: 30
             periodSeconds: 60
             timeoutSeconds: 5
           readinessProbe:
             httpGet:
               path: {{ (.Values.readinessProbe).path | default "/" }}
               port: http
-            initialDelaySeconds: 30
             periodSeconds: 30
             timeoutSeconds: 5
+          startupProbe:
+            httpGet:
+              path: {{ (.Values.livenessProbe).path | default "/" }}
+              port: http
+              scheme: HTTP
+            timeoutSeconds: 5
+            periodSeconds: 5
+            failureThreshold: 30
           env:
             - name: ENV
               value: {{ .Values.global.env }}

--- a/charts/bandstand-web-service/templates/deployment.yaml
+++ b/charts/bandstand-web-service/templates/deployment.yaml
@@ -97,7 +97,6 @@ spec:
             httpGet:
               path: {{ (.Values.livenessProbe).path | default "/" }}
               port: http
-              scheme: HTTP
             timeoutSeconds: 5
             periodSeconds: 5
             failureThreshold: 30


### PR DESCRIPTION
Speed up web service deployments by 40-50s per replica by adding a startup probe.