### PR TITLE
DEP-2458 Prevent jobs and tests being disrupted by Karpenter

### DIFF
--- a/charts/bandstand-cron-job/Chart.yaml
+++ b/charts/bandstand-cron-job/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bandstand-cron-job
-version: 4.3.3
+version: 4.3.4
 description: Application chart for a simple cron job
 type: application
 maintainers:

--- a/charts/bandstand-cron-job/templates/cronjob.yaml
+++ b/charts/bandstand-cron-job/templates/cronjob.yaml
@@ -17,6 +17,7 @@ spec:
         metadata:
           annotations:
             "linkerd.io/inject": disabled
+            "karpenter.sh/do-not-disrupt": "true"
           labels: {{- include "bandstand-cron-job.labels" . | nindent 12 }}
         spec:
           serviceAccountName: {{ .Release.Name }}

--- a/charts/bandstand-job/Chart.yaml
+++ b/charts/bandstand-job/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bandstand-job
-version: 1.3.2
+version: 1.3.3
 description: Application chart for a simple job starting immediately after deployment
 type: application
 maintainers:

--- a/charts/bandstand-job/templates/job.yaml
+++ b/charts/bandstand-job/templates/job.yaml
@@ -10,6 +10,7 @@ spec:
     metadata:
       annotations:
         "linkerd.io/inject": disabled
+        "karpenter.sh/do-not-disrupt": "true"
       labels: {{- include "bandstand-job.labels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ .Release.Name }}

--- a/charts/bandstand-web-service/Chart.yaml
+++ b/charts/bandstand-web-service/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bandstand-web-service
-version: 4.10.1
+version: 4.10.2
 description: Application chart for a web service
 type: application
 maintainers:

--- a/charts/bandstand-web-service/templates/tests/pod.yaml
+++ b/charts/bandstand-web-service/templates/tests/pod.yaml
@@ -18,6 +18,7 @@ metadata:
     "polaris.fairwinds.com/readinessProbeMissing-exempt": "true"
     "polaris.fairwinds.com/livenessProbeMissing-exempt": "true"
     "linkerd.io/inject": disabled
+    "karpenter.sh/do-not-disrupt": "true"
 spec:
   {{- if (.Values.test).createServiceAccount }}
   serviceAccountName: {{ $relName }}-acceptance-tests


### PR DESCRIPTION
Prevents jobs and tests being disrupted by karpenter, as they may be configured to run just once so disruption could cause issues