### PR TITLE
inc-62-nginx-security-alert: Remove server-snippet annotation (web, confluent) - ingress incident

### DIFF
--- a/charts/bandstand-confluent-connect/Chart.yaml
+++ b/charts/bandstand-confluent-connect/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bandstand-confluent-connect
-version: 1.2.8
+version: 1.2.9
 description: Chart for deploying confluent connect clusters and connectors
 type: application
 sources:

--- a/charts/bandstand-confluent-connect/templates/ingress.yaml
+++ b/charts/bandstand-confluent-connect/templates/ingress.yaml
@@ -17,8 +17,6 @@ metadata:
     nginx.ingress.kubernetes.io/service-upstream: "true"
     nginx.ingress.kubernetes.io/proxy-buffering: "on"
     nginx.ingress.kubernetes.io/proxy-buffer-size: "16k"
-    nginx.ingress.kubernetes.io/server-snippet: |
-      large_client_header_buffers 4 16k;
     {{- with .Values.ingress.annotations }}
       {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/charts/bandstand-web-service/Chart.yaml
+++ b/charts/bandstand-web-service/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bandstand-web-service
-version: 4.10.2
+version: 4.10.3
 description: Application chart for a web service
 type: application
 maintainers:

--- a/charts/bandstand-web-service/templates/ingress.yaml
+++ b/charts/bandstand-web-service/templates/ingress.yaml
@@ -13,8 +13,6 @@ metadata:
     nginx.ingress.kubernetes.io/service-upstream: "true"
     nginx.ingress.kubernetes.io/proxy-buffering: "on"
     nginx.ingress.kubernetes.io/proxy-buffer-size: "16k"
-    nginx.ingress.kubernetes.io/server-snippet: |
-      large_client_header_buffers 4 16k;
     {{- with .Values.ingress.annotations }}
       {{- toYaml . | nindent 4 }}
     {{- end }}


### PR DESCRIPTION
Remove server-snippet annotation (web, confluent) - ingress incident