### PR TITLE
DEP-2114 Allow templating in env vars

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,6 +30,7 @@ workflows:
             parameters:
               chart:
                 - test-charts/web-service/defaults
+                - test-charts/web-service/envvars
                 - test-charts/web-service/advanced-scaling
                 - test-charts/web-service/image-override
                 - test-charts/web-service/pre-stop-wait
@@ -45,6 +46,7 @@ workflows:
                 - test-charts/web-service/with-persistent-volume
                 - test-charts/web-service/reloader
                 - test-charts/headless-service/defaults
+                - test-charts/headless-service/envvars
                 - test-charts/headless-service/advanced-scaling
                 - test-charts/headless-service/image-override
                 - test-charts/headless-service/resources
@@ -56,6 +58,7 @@ workflows:
                 - test-charts/headless-service/with-persistent-volume
                 - test-charts/headless-service/reloader
                 - test-charts/job/defaults
+                - test-charts/job/envvars
                 - test-charts/job/image-override
                 - test-charts/job/resources
                 - test-charts/job/resource-limits
@@ -77,6 +80,7 @@ workflows:
                 - test-charts/cron-job/with-ephemeral-volume
                 - test-charts/cron-job/with-persistent-volume
                 - test-charts/triggered-job/defaults
+                - test-charts/triggered-job/envvars
                 - test-charts/triggered-job/image-override
                 - test-charts/triggered-job/resources
                 - test-charts/triggered-job/resource-limits

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,6 +66,7 @@ workflows:
                 - test-charts/job/with-ephemeral-volume
                 - test-charts/job/with-persistent-volume
                 - test-charts/cron-job/defaults
+                - test-charts/cron-job/envvars
                 - test-charts/cron-job/image-override
                 - test-charts/cron-job/resources
                 - test-charts/cron-job/resource-limits

--- a/charts/bandstand-cron-job/Chart.yaml
+++ b/charts/bandstand-cron-job/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bandstand-cron-job
-version: 4.3.4
+version: 4.4.0
 description: Application chart for a simple cron job
 type: application
 maintainers:

--- a/charts/bandstand-cron-job/templates/cronjob.yaml
+++ b/charts/bandstand-cron-job/templates/cronjob.yaml
@@ -69,10 +69,10 @@ spec:
                   ephemeral-storage: {{ (.Values.resources).requests.ephemeralStorage | default "64Mi" }}
               env: {{- include "bandstand-cron-job.common-envvars" . | nindent 16 }}
                 {{- if .Values.additionalEnvVars }}
-                {{- tpl .Values.additionalEnvVars | toYaml | trimPrefix "|" | trimPrefix "\n" | nindent 16 }}
+                {{- tpl .Values.additionalEnvVars $ | toYaml | trimPrefix "|" | trimPrefix "\n" | nindent 16 }}
                 {{- end }}
                 {{- if .Values.environmentEnvVars }}
-                {{- tpl .Values.environmentEnvVars | toYaml | trimPrefix "|" | trimPrefix "\n" | nindent 16 }}
+                {{- tpl .Values.environmentEnvVars $ | toYaml | trimPrefix "|" | trimPrefix "\n" | nindent 16 }}
                 {{- end }}
               {{- if or (.Values.envFrom) (.Values.secrets) }}
               envFrom:

--- a/charts/bandstand-cron-job/templates/cronjob.yaml
+++ b/charts/bandstand-cron-job/templates/cronjob.yaml
@@ -69,10 +69,10 @@ spec:
                   ephemeral-storage: {{ (.Values.resources).requests.ephemeralStorage | default "64Mi" }}
               env: {{- include "bandstand-cron-job.common-envvars" . | nindent 16 }}
                 {{- if .Values.additionalEnvVars }}
-                {{- .Values.additionalEnvVars | toYaml | trimPrefix "|" | trimPrefix "\n" | nindent 16 }}
+                {{- tpl .Values.additionalEnvVars | toYaml | trimPrefix "|" | trimPrefix "\n" | nindent 16 }}
                 {{- end }}
                 {{- if .Values.environmentEnvVars }}
-                {{- .Values.environmentEnvVars | toYaml | trimPrefix "|" | trimPrefix "\n" | nindent 16 }}
+                {{- tpl .Values.environmentEnvVars | toYaml | trimPrefix "|" | trimPrefix "\n" | nindent 16 }}
                 {{- end }}
               {{- if or (.Values.envFrom) (.Values.secrets) }}
               envFrom:

--- a/charts/bandstand-cron-job/templates/cronjob.yaml
+++ b/charts/bandstand-cron-job/templates/cronjob.yaml
@@ -69,10 +69,10 @@ spec:
                   ephemeral-storage: {{ (.Values.resources).requests.ephemeralStorage | default "64Mi" }}
               env: {{- include "bandstand-cron-job.common-envvars" . | nindent 16 }}
                 {{- if .Values.additionalEnvVars }}
-                {{- (tpl .Values.additionalEnvVars $) | toYaml | trimPrefix "|" | trimPrefix "\n" | nindent 16 }}
+                {{- .Values.additionalEnvVars | toYaml | trimPrefix "|" | trimPrefix "\n" | nindent 16 | tpl $ }}
                 {{- end }}
                 {{- if .Values.environmentEnvVars }}
-                {{- (tpl .Values.environmentEnvVars $) | toYaml | trimPrefix "|" | trimPrefix "\n" | nindent 16 }}
+                {{- .Values.environmentEnvVars | toYaml | trimPrefix "|" | trimPrefix "\n" | nindent 16 | tpl $ }}
                 {{- end }}
               {{- if or (.Values.envFrom) (.Values.secrets) }}
               envFrom:

--- a/charts/bandstand-cron-job/templates/cronjob.yaml
+++ b/charts/bandstand-cron-job/templates/cronjob.yaml
@@ -69,10 +69,10 @@ spec:
                   ephemeral-storage: {{ (.Values.resources).requests.ephemeralStorage | default "64Mi" }}
               env: {{- include "bandstand-cron-job.common-envvars" . | nindent 16 }}
                 {{- if .Values.additionalEnvVars }}
-                {{- tpl (.Values.additionalEnvVars | toString) $ | toYaml | trimPrefix "|" | trimPrefix "\n" | nindent 16 }}
+                {{- tpl (.Values.additionalEnvVars | toYaml) $ | trimPrefix "|" | trimPrefix "\n" | nindent 16 }}
                 {{- end }}
                 {{- if .Values.environmentEnvVars }}
-                {{- tpl (.Values.environmentEnvVars | toString) $ | toYaml | trimPrefix "|" | trimPrefix "\n" | nindent 16 | tpl $ }}
+                {{- tpl (.Values.environmentEnvVars | toYaml) $ | trimPrefix "|" | trimPrefix "\n" | nindent 16 }}
                 {{- end }}
               {{- if or (.Values.envFrom) (.Values.secrets) }}
               envFrom:

--- a/charts/bandstand-cron-job/templates/cronjob.yaml
+++ b/charts/bandstand-cron-job/templates/cronjob.yaml
@@ -69,10 +69,10 @@ spec:
                   ephemeral-storage: {{ (.Values.resources).requests.ephemeralStorage | default "64Mi" }}
               env: {{- include "bandstand-cron-job.common-envvars" . | nindent 16 }}
                 {{- if .Values.additionalEnvVars }}
-                {{- .Values.additionalEnvVars | toYaml | trimPrefix "|" | trimPrefix "\n" | nindent 16 | tpl $ }}
+                {{- tpl (.Values.additionalEnvVars | toString) $ | toYaml | trimPrefix "|" | trimPrefix "\n" | nindent 16 }}
                 {{- end }}
                 {{- if .Values.environmentEnvVars }}
-                {{- .Values.environmentEnvVars | toYaml | trimPrefix "|" | trimPrefix "\n" | nindent 16 | tpl $ }}
+                {{- tpl (.Values.environmentEnvVars | toString) $ | toYaml | trimPrefix "|" | trimPrefix "\n" | nindent 16 | tpl $ }}
                 {{- end }}
               {{- if or (.Values.envFrom) (.Values.secrets) }}
               envFrom:

--- a/charts/bandstand-cron-job/templates/cronjob.yaml
+++ b/charts/bandstand-cron-job/templates/cronjob.yaml
@@ -69,10 +69,10 @@ spec:
                   ephemeral-storage: {{ (.Values.resources).requests.ephemeralStorage | default "64Mi" }}
               env: {{- include "bandstand-cron-job.common-envvars" . | nindent 16 }}
                 {{- if .Values.additionalEnvVars }}
-                {{- tpl .Values.additionalEnvVars $ | toYaml | trimPrefix "|" | trimPrefix "\n" | nindent 16 }}
+                {{- (tpl .Values.additionalEnvVars $) | toYaml | trimPrefix "|" | trimPrefix "\n" | nindent 16 }}
                 {{- end }}
                 {{- if .Values.environmentEnvVars }}
-                {{- tpl .Values.environmentEnvVars $ | toYaml | trimPrefix "|" | trimPrefix "\n" | nindent 16 }}
+                {{- (tpl .Values.environmentEnvVars $) | toYaml | trimPrefix "|" | trimPrefix "\n" | nindent 16 }}
                 {{- end }}
               {{- if or (.Values.envFrom) (.Values.secrets) }}
               envFrom:

--- a/charts/bandstand-headless-service/Chart.yaml
+++ b/charts/bandstand-headless-service/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bandstand-headless-service
-version: 3.6.1
+version: 3.7.0
 description: Chart for a standalone (non-web) service
 type: application
 maintainers:

--- a/charts/bandstand-headless-service/templates/deployment.yaml
+++ b/charts/bandstand-headless-service/templates/deployment.yaml
@@ -107,10 +107,10 @@ spec:
             - name: AWS_ACCOUNT_ID
               value: {{ .Values.global.aws.account | squote }}
             {{- if .Values.additionalEnvVars }}
-              {{- .Values.additionalEnvVars | toYaml | trimPrefix "|" | trimPrefix "\n" | nindent 12 }}
+              {{- tpl (.Values.additionalEnvVars | toYaml) $ | trimPrefix "|" | trimPrefix "\n" | nindent 12 }}
             {{- end }}
             {{- if .Values.environmentEnvVars }}
-              {{- .Values.environmentEnvVars | toYaml | trimPrefix "|" | trimPrefix "\n" | nindent 12 }}
+              {{- tpl (.Values.environmentEnvVars | toYaml) $ | trimPrefix "|" | trimPrefix "\n" | nindent 12 }}
             {{- end }}
           {{- if or (.Values.envFrom) (.Values.secrets) }}
           envFrom:

--- a/charts/bandstand-job/Chart.yaml
+++ b/charts/bandstand-job/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bandstand-job
-version: 1.3.3
+version: 1.4.0
 description: Application chart for a simple job starting immediately after deployment
 type: application
 maintainers:

--- a/charts/bandstand-job/templates/job.yaml
+++ b/charts/bandstand-job/templates/job.yaml
@@ -62,10 +62,10 @@ spec:
               ephemeral-storage: {{ (.Values.resources).requests.ephemeralStorage | default "64Mi" }}
           env: {{- include "bandstand-job.common-envvars" . | nindent 16 }}
             {{- if .Values.additionalEnvVars }}
-            {{- .Values.additionalEnvVars | toYaml | trimPrefix "|" | trimPrefix "\n" | nindent 16 }}
+            {{- tpl (.Values.additionalEnvVars | toYaml) $ | trimPrefix "|" | trimPrefix "\n" | nindent 16 }}
             {{- end }}
             {{- if .Values.environmentEnvVars }}
-            {{- .Values.environmentEnvVars | toYaml | trimPrefix "|" | trimPrefix "\n" | nindent 16 }}
+            {{- tpl (.Values.environmentEnvVars | toYaml) $ | trimPrefix "|" | trimPrefix "\n" | nindent 16 }}
             {{- end }}
           {{- if or (.Values.envFrom) (.Values.secrets) }}
           envFrom:

--- a/charts/bandstand-triggered-job/Chart.yaml
+++ b/charts/bandstand-triggered-job/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bandstand-triggered-job
-version: 1.4.2
+version: 1.5.0
 description: Application chart for a job triggered from SQS
 type: application
 maintainers:

--- a/charts/bandstand-triggered-job/templates/scaledjob.yaml
+++ b/charts/bandstand-triggered-job/templates/scaledjob.yaml
@@ -68,10 +68,10 @@ spec:
                 ephemeral-storage: {{ (.Values.resources).requests.ephemeralStorage | default "64Mi" }}
             env: {{- include "bandstand-triggered-job.common-envvars" . | nindent 16 }}
               {{- if .Values.additionalEnvVars }}
-              {{- .Values.additionalEnvVars | toYaml | trimPrefix "|" | trimPrefix "\n" | nindent 16 }}
+              {{- tpl (.Values.additionalEnvVars | toYaml) $ | trimPrefix "|" | trimPrefix "\n" | nindent 16 }}
               {{- end }}
               {{- if .Values.environmentEnvVars }}
-              {{- .Values.environmentEnvVars | toYaml | trimPrefix "|" | trimPrefix "\n" | nindent 16 }}
+              {{- tpl (.Values.environmentEnvVars | toYaml) $ | trimPrefix "|" | trimPrefix "\n" | nindent 16 }}
               {{- end }}
             {{- if or (.Values.envFrom) (.Values.secrets) }}
             envFrom:

--- a/charts/bandstand-web-service/Chart.yaml
+++ b/charts/bandstand-web-service/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bandstand-web-service
-version: 4.10.2
+version: 4.11.0
 description: Application chart for a web service
 type: application
 maintainers:

--- a/charts/bandstand-web-service/templates/deployment.yaml
+++ b/charts/bandstand-web-service/templates/deployment.yaml
@@ -140,10 +140,10 @@ spec:
             - name: AWS_ACCOUNT_ID
               value: {{ .Values.global.aws.account | squote }}
             {{- if .Values.additionalEnvVars }}
-              {{- .Values.additionalEnvVars | toYaml | trimPrefix "|" | trimPrefix "\n" | nindent 12 }}
+              {{- tpl (.Values.additionalEnvVars | toYaml) $ | trimPrefix "|" | trimPrefix "\n" | nindent 12 }}
             {{- end }}
             {{- if .Values.environmentEnvVars }}
-              {{- .Values.environmentEnvVars | toYaml | trimPrefix "|" | trimPrefix "\n" | nindent 12 }}
+              {{- tpl (.Values.environmentEnvVars | toYaml) $ | trimPrefix "|" | trimPrefix "\n" | nindent 12 }}
             {{- end }}
           {{- if or (.Values.envFrom) (.Values.secrets) }}
           envFrom:

--- a/charts/bandstand-web-service/templates/tests/pod.yaml
+++ b/charts/bandstand-web-service/templates/tests/pod.yaml
@@ -49,10 +49,10 @@ spec:
         - name: ENV
           value: {{ .Values.global.env }}
         {{- if (.Values.test).additionalEnvVars }}
-          {{- .Values.test.additionalEnvVars | toYaml | trimPrefix "|" | trimPrefix "\n" | nindent 8 }}
+          {{- tpl (.Values.test.additionalEnvVars | toYaml) $ | trimPrefix "|" | trimPrefix "\n" | nindent 8 }}
         {{- end }}
         {{- if (.Values.test).environmentEnvVars }}
-          {{- .Values.test.environmentEnvVars | toYaml | trimPrefix "|" | trimPrefix "\n" | nindent 8 }}
+          {{- tpl (.Values.test.environmentEnvVars | toYaml) $ | trimPrefix "|" | trimPrefix "\n" | nindent 8 }}
         {{- end }}
       {{- if or ((.Values.test).envFrom) ((.Values.test).secrets) }}
       envFrom:

--- a/test-charts/cron-job/envvars/Chart.yaml
+++ b/test-charts/cron-job/envvars/Chart.yaml
@@ -1,0 +1,13 @@
+apiVersion: v2
+name: cron-job-defaults
+version: 1.0.0
+description: testing bandstand-cron-job chart
+type: application
+sources:
+  - https://github.com/ktech-org/bandstand-charts
+dependencies:
+  - name: bandstand-cron-job
+    version: ">= 3.0.0"
+    repository: "file://../../../charts/bandstand-cron-job/"
+maintainers:
+  - name: ktech-developer-platform

--- a/test-charts/cron-job/envvars/values.yaml
+++ b/test-charts/cron-job/envvars/values.yaml
@@ -1,0 +1,12 @@
+bandstand-cron-job:
+  owner: ktech-developer-platform
+  env: test
+  business: ktech
+
+  additionalEnvVars:
+    - name: SOME_URL
+      value: https://exmaple.{{ .Values.global.env }}.com
+
+  environmentEnvVars:
+    - name: SOME_ENV_URL
+      value: https://example.env.{{ .Values.global.env }}.com

--- a/test-charts/cron-job/secrets/values.yaml
+++ b/test-charts/cron-job/secrets/values.yaml
@@ -12,4 +12,4 @@ bandstand-cron-job:
       secret: my-other-secret-name
       upperCaseKeys: true
     - name: my-templated-secret
-      secret: my-{{.Values.env}}-secret-name
+      secret: my-{{.Values.global.env}}-secret-name

--- a/test-charts/headless-service/envvars/Chart.yaml
+++ b/test-charts/headless-service/envvars/Chart.yaml
@@ -1,0 +1,13 @@
+apiVersion: v2
+name: headless-service-defaults
+version: 1.0.0
+description: testing bandstand-headless-service chart
+type: application
+sources:
+  - https://github.com/ktech-org/bandstand-charts
+dependencies:
+  - name: bandstand-headless-service
+    version: ">= 1.0.0"
+    repository: "file://../../../charts/bandstand-headless-service/"
+maintainers:
+  - name: ktech-developer-platform

--- a/test-charts/headless-service/envvars/values.yaml
+++ b/test-charts/headless-service/envvars/values.yaml
@@ -1,4 +1,4 @@
-bandstand-cron-job:
+bandstand-headless-service:
   owner: ktech-developer-platform
   env: test
   business: ktech

--- a/test-charts/job/envvars/Chart.yaml
+++ b/test-charts/job/envvars/Chart.yaml
@@ -1,0 +1,13 @@
+apiVersion: v2
+name: job-defaults
+version: 1.0.0
+description: testing bandstand-job chart
+type: application
+sources:
+  - https://github.com/ktech-org/bandstand-charts
+dependencies:
+  - name: bandstand-job
+    version: ">= 1.0.0"
+    repository: "file://../../../charts/bandstand-job/"
+maintainers:
+  - name: ktech-developer-platform

--- a/test-charts/job/envvars/values.yaml
+++ b/test-charts/job/envvars/values.yaml
@@ -1,4 +1,4 @@
-bandstand-cron-job:
+bandstand-job:
   owner: ktech-developer-platform
   env: test
   business: ktech

--- a/test-charts/triggered-job/envvars/Chart.yaml
+++ b/test-charts/triggered-job/envvars/Chart.yaml
@@ -1,0 +1,13 @@
+apiVersion: v2
+name: triggered-job-defaults
+version: 1.0.0
+description: testing bandstand-triggered-job chart
+type: application
+sources:
+  - https://github.com/ktech-org/bandstand-charts
+dependencies:
+  - name: bandstand-triggered-job
+    version: ">= 1.0.0"
+    repository: "file://../../../charts/bandstand-triggered-job/"
+maintainers:
+  - name: ktech-developer-platform

--- a/test-charts/triggered-job/envvars/values.yaml
+++ b/test-charts/triggered-job/envvars/values.yaml
@@ -1,4 +1,4 @@
-bandstand-cron-job:
+bandstand-triggered-job:
   owner: ktech-developer-platform
   env: test
   business: ktech

--- a/test-charts/web-service/envvars/Chart.yaml
+++ b/test-charts/web-service/envvars/Chart.yaml
@@ -1,0 +1,13 @@
+apiVersion: v2
+name: web-service-defaults
+version: 1.0.0
+description: testing bandstand-web-service chart
+type: application
+sources:
+  - https://github.com/ktech-org/bandstand-charts
+dependencies:
+  - name: bandstand-web-service
+    version: ">= 3.0.0"
+    repository: "file://../../../charts/bandstand-web-service/"
+maintainers:
+  - name: ktech-developer-platform

--- a/test-charts/web-service/envvars/values.yaml
+++ b/test-charts/web-service/envvars/values.yaml
@@ -1,7 +1,10 @@
-bandstand-cron-job:
+bandstand-web-service:
   owner: ktech-developer-platform
   env: test
   business: ktech
+
+  ingress:
+    enabled: false
 
   additionalEnvVars:
     - name: SOME_URL


### PR DESCRIPTION
As mentioned in [help channel ](https://kobaltmusic.slack.com/archives/C012P5W7Z19/p1743179194158229) - add the ability to have templating in definition of helm chart envvars (e.g. substitute values)