### PR TITLE
DEP-2478: Ephemeral volumes for bandstand-triggered-job

### DIFF
--- a/charts/bandstand-triggered-job/Chart.yaml
+++ b/charts/bandstand-triggered-job/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bandstand-triggered-job
-version: 1.5.0
+version: 1.5.1
 description: Application chart for a job triggered from SQS
 type: application
 maintainers:

--- a/charts/bandstand-triggered-job/templates/_helpers.tpl
+++ b/charts/bandstand-triggered-job/templates/_helpers.tpl
@@ -32,19 +32,19 @@ fsGroup: {{ .Values.fsGroup | default 1000  }}
 
 {{- define "bandstand-triggered-job.common-volumes" -}}
 - name: tmp-dir
-  {{- if (.Values.volume).ephemeral }}
-    ephemeral:
-      volumeClaimTemplate:
-        metadata:
-          labels:
-            type: temp-volume
-        spec:
-          accessModes: [ "ReadWriteOnce" ]
-          storageClassName: "gp2"
-          resources:
-            requests:
-              storage: {{ .Values.volume.ephemeral }}
-  {{- else }}
+{{- if (.Values.volume).ephemeral }}
+  ephemeral:
+    volumeClaimTemplate:
+      metadata:
+        labels:
+          type: temp-volume
+      spec:
+        accessModes: [ "ReadWriteOnce" ]
+        storageClassName: "gp2"
+        resources:
+          requests:
+            storage: {{ .Values.volume.ephemeral }}
+{{- else }}
   emptyDir: {}
 {{- if .Values.config }}
 - name: config

--- a/charts/bandstand-triggered-job/templates/_helpers.tpl
+++ b/charts/bandstand-triggered-job/templates/_helpers.tpl
@@ -46,6 +46,7 @@ fsGroup: {{ .Values.fsGroup | default 1000  }}
             storage: {{ .Values.volume.ephemeral }}
 {{- else }}
   emptyDir: {}
+{{- end }}
 {{- if .Values.config }}
 - name: config
   configMap:

--- a/charts/bandstand-triggered-job/templates/_helpers.tpl
+++ b/charts/bandstand-triggered-job/templates/_helpers.tpl
@@ -32,6 +32,19 @@ fsGroup: {{ .Values.fsGroup | default 1000  }}
 
 {{- define "bandstand-triggered-job.common-volumes" -}}
 - name: tmp-dir
+  {{- if (.Values.volume).ephemeral }}
+    ephemeral:
+      volumeClaimTemplate:
+        metadata:
+          labels:
+            type: temp-volume
+        spec:
+          accessModes: [ "ReadWriteOnce" ]
+          storageClassName: "gp2"
+          resources:
+            requests:
+              storage: {{ .Values.volume.ephemeral }}
+  {{- else }}
   emptyDir: {}
 {{- if .Values.config }}
 - name: config


### PR DESCRIPTION
Josh's team pointed out that ephemeral volumes not enabled for bandstand-triggered-job - we already have it for [job](https://github.com/ktech-org/bandstand-charts/blob/main/charts/bandstand-job/templates/_helpers.tpl#L35-L47) and [web service](https://github.com/ktech-org/bandstand-charts/blob/main/charts/bandstand-web-service/templates/deployment.yaml#L197-L208).