### PR TITLE
add otel metrics for triggered job

### DIFF
--- a/charts/bandstand-triggered-job/Chart.yaml
+++ b/charts/bandstand-triggered-job/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bandstand-triggered-job
-version: 1.5.2
+version: 1.5.3
 description: Application chart for a job triggered from SQS
 type: application
 maintainers:

--- a/charts/bandstand-triggered-job/templates/_helpers.tpl
+++ b/charts/bandstand-triggered-job/templates/_helpers.tpl
@@ -91,6 +91,26 @@ fsGroup: {{ .Values.fsGroup | default 1000  }}
   valueFrom:
     fieldRef:
       fieldPath: status.hostIP
+- name: OTEL_SERVICE_NAME
+  value: {{ .Release.Name }}
+- name: OTEL_EXPORTER_OTLP_ENDPOINT
+  value: http://collector.linkerd-jaeger:4317
+- name: OTEL_PROPAGATORS
+  value: b3multi
+- name: OTEL_EXPORTER_OTLP_METRICS_ENDPOINT
+  value: http://$(DD_AGENT_HOST):4317
+- name: OTEL_EXPORTER_OTLP_METRICS_PROTOCOL
+  value: grpc
+- name: OTEL_METRICS_EXPORTER
+  value: otlp
+- name: OTEL_EXPORTER_OTLP_PROTOCOL
+  value: grpc
+- name: OTEL_LOGS_EXPORTER
+  value: none
+- name: OTEL_JAVA_DISABLED_RESOURCE_PROVIDERS
+  value: io.opentelemetry.sdk.extension.resources.HostResourceProvider,io.opentelemetry.sdk.extension.resources.ContainerResourceProvider
+- name: OTEL_RESOURCE_ATTRIBUTES
+  value: host=$(DD_AGENT_HOST),service={{ .Release.Name }},env={{ .Values.global.env }}
 - name: QUEUE_URL
   value: https://sqs.eu-west-1.amazonaws.com/{{ .Values.global.aws.account | toYaml }}/{{ .Values.queueName }}
 - name: AWS_ACCOUNT_ID


### PR DESCRIPTION
from help on 29-Apr-25 at 3:19pm
We would like to emit metrics to datadog from a bandstand trigger job, but it doesn’t seem to work.
The cron jobs seem to have the OTEL_* variables configured but not the trigger jobs.