### PR TITLE
DEP-2511 Use Dockerhub pull secret for Connect

### DIFF
--- a/charts/bandstand-confluent-connect/Chart.yaml
+++ b/charts/bandstand-confluent-connect/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bandstand-confluent-connect
-version: 1.2.8
+version: 1.2.9
 description: Chart for deploying confluent connect clusters and connectors
 type: application
 sources:

--- a/charts/bandstand-confluent-connect/templates/connect.yaml
+++ b/charts/bandstand-confluent-connect/templates/connect.yaml
@@ -13,6 +13,8 @@ spec:
     application: {{ .Values.applicationImage }}
     init: {{ .Values.initImage }}
     pullPolicy: Always
+    pullSecretRef:
+      - name: dockerhub-config
   build:
     type: onDemand
     onDemand:


### PR DESCRIPTION
## Description
Use the dockerhub image pull secret when deploying confluent connect
## Checklist

- [ ] I have updated the affected chart versions
- [ ] I have updated the documentation accordingly and documented any new attributes
- [ ] I have added new tests and incorporated them into the build
