### PR TITLE
add allow-other mount option

### DIFF
--- a/charts/bandstand-cron-job/Chart.yaml
+++ b/charts/bandstand-cron-job/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bandstand-cron-job
-version: 4.6.3
+version: 4.6.4
 description: Application chart for a simple cron job
 type: application
 maintainers:

--- a/charts/bandstand-cron-job/templates/pv.yaml
+++ b/charts/bandstand-cron-job/templates/pv.yaml
@@ -22,10 +22,11 @@ spec:
     volumeAttributes:
       bucketName: {{ $volume.bucketName }}
       authenticationSource: pod
-  {{- if $volume.prefix }}
   mountOptions:
-    - prefix {{ $volume.prefix }}
-  {{- end }}
+    {{- if $volume.prefix }}
+    - prefix={{ $volume.prefix }}
+    {{- end }}
+    - allow-other
   claimRef:
     namespace: {{ $root.Release.Namespace }}
     name: {{ printf "%s-pvc" $volName }}


### PR DESCRIPTION
## Description
Add the  "- allow-other" mount option as detailed [here](https://github.com/awslabs/mountpoint-s3-csi-driver/blob/8f9fda72a448d9f1aeda31807557450b5e8fe624/examples/kubernetes/static_provisioning/non_root.yaml#L17).

## Checklist

- [ ] I have updated the affected chart versions
- [ ] I have updated the documentation accordingly and documented any new attributes
- [ ] I have added new tests and incorporated them into the build
