### PR TITLE
DEP-287 Ensure common labels applied to all resources

### DIFF
--- a/charts/bandstand-confluent-connect/Chart.yaml
+++ b/charts/bandstand-confluent-connect/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bandstand-confluent-connect
-version: 1.2.10
+version: 1.2.11
 description: Chart for deploying confluent connect clusters and connectors
 type: application
 sources:

--- a/charts/bandstand-confluent-connect/templates/external-secret-connect.yaml
+++ b/charts/bandstand-confluent-connect/templates/external-secret-connect.yaml
@@ -6,6 +6,7 @@ apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: {{ $relName }}
+  labels: {{- include "bandstand-confluent-connect.labels" . | nindent 4 }}
   annotations:
     force-sync: '{{ now | unixEpoch }}'
 spec:

--- a/charts/bandstand-cron-job/Chart.yaml
+++ b/charts/bandstand-cron-job/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bandstand-cron-job
-version: 4.6.4
+version: 4.6.5
 description: Application chart for a simple cron job
 type: application
 maintainers:

--- a/charts/bandstand-cron-job/templates/extsecrets.yaml
+++ b/charts/bandstand-cron-job/templates/extsecrets.yaml
@@ -5,6 +5,7 @@ apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: {{ $secretName }}
+  labels: {{- include "bandstand-cron-job.labels" $ | nindent 4 }}
   annotations:
     force-sync: '{{ now | unixEpoch }}'
 spec:
@@ -22,6 +23,6 @@ spec:
         {{- if .upperCaseKeys }}
         - transform:
             template: {{`'{{ .value | upper }}'`}}
-        {{- end}}
+        {{- end }}
 ---
 {{- end }}

--- a/charts/bandstand-headless-service/Chart.yaml
+++ b/charts/bandstand-headless-service/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bandstand-headless-service
-version: 3.8.0
+version: 3.8.1
 description: Chart for a standalone (non-web) service
 type: application
 maintainers:

--- a/charts/bandstand-headless-service/templates/extsecrets.yaml
+++ b/charts/bandstand-headless-service/templates/extsecrets.yaml
@@ -5,6 +5,7 @@ apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: {{ $secretName }}
+  labels: {{- include "bandstand-headless-service.labels" $ | nindent 4 }}
   annotations:
     force-sync: '{{ now | unixEpoch }}'
 spec:
@@ -22,6 +23,6 @@ spec:
         {{- if .upperCaseKeys }}
         - transform:
             template: {{`'{{ .value | upper }}'`}}
-        {{- end}}
+        {{- end }}
 ---
 {{- end }}

--- a/charts/bandstand-headless-service/templates/scaled-object.yaml
+++ b/charts/bandstand-headless-service/templates/scaled-object.yaml
@@ -7,6 +7,7 @@ apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
 metadata:
   name: {{ $relName }}
+  labels: {{- include "bandstand-headless-service.labels" . | nindent 4 }}
 spec:
   cooldownPeriod: {{ (.Values.advancedScaling.cooldown) | default 30 }}
   maxReplicaCount: {{ (.Values.advancedScaling.maxReplicas) | default 3 }}

--- a/charts/bandstand-job/Chart.yaml
+++ b/charts/bandstand-job/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bandstand-job
-version: 1.4.1
+version: 1.4.2
 description: Application chart for a simple job starting immediately after deployment
 type: application
 maintainers:

--- a/charts/bandstand-job/templates/extsecrets.yaml
+++ b/charts/bandstand-job/templates/extsecrets.yaml
@@ -5,6 +5,7 @@ apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: {{ $secretName }}
+  labels: {{- include "bandstand-job.labels" $ | nindent 4 }}
   annotations:
     force-sync: '{{ now | unixEpoch }}'
 spec:
@@ -22,6 +23,6 @@ spec:
         {{- if .upperCaseKeys }}
         - transform:
             template: {{`'{{ .value | upper }}'`}}
-        {{- end}}
+        {{- end }}
 ---
 {{- end }}

--- a/charts/bandstand-test-runner/Chart.yaml
+++ b/charts/bandstand-test-runner/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bandstand-test-runner
-version: 2.6.1
+version: 2.6.2
 description: Application for running standalone test pod
 type: application
 maintainers:

--- a/charts/bandstand-test-runner/templates/extsecrets.yaml
+++ b/charts/bandstand-test-runner/templates/extsecrets.yaml
@@ -5,6 +5,7 @@ apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: {{ $secretName }}
+  labels: {{- include "bandstand-test-runner.labels" $ | nindent 4 }}
   annotations:
     force-sync: '{{ now | unixEpoch }}'
 spec:
@@ -22,6 +23,6 @@ spec:
         {{- if .upperCaseKeys }}
         - transform:
             template: {{`'{{ .value | upper }}'`}}
-        {{- end}}
+        {{- end }}
 ---
 {{- end }}

--- a/charts/bandstand-triggered-job/Chart.yaml
+++ b/charts/bandstand-triggered-job/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bandstand-triggered-job
-version: 1.8.0
+version: 1.8.1
 description: Application chart for a job triggered from SQS
 type: application
 maintainers:

--- a/charts/bandstand-triggered-job/templates/extsecrets.yaml
+++ b/charts/bandstand-triggered-job/templates/extsecrets.yaml
@@ -5,6 +5,7 @@ apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: {{ $secretName }}
+  labels: {{- include "bandstand-triggered-job.labels" $ | nindent 4 }}
   annotations:
     force-sync: '{{ now | unixEpoch }}'
 spec:
@@ -22,6 +23,6 @@ spec:
         {{- if .upperCaseKeys }}
         - transform:
             template: {{`'{{ .value | upper }}'`}}
-        {{- end}}
+        {{- end }}
 ---
 {{- end }}

--- a/charts/bandstand-web-service/Chart.yaml
+++ b/charts/bandstand-web-service/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bandstand-web-service
-version: 4.12.0
+version: 4.12.1
 description: Application chart for a web service
 type: application
 maintainers:

--- a/charts/bandstand-web-service/templates/certificate.yaml
+++ b/charts/bandstand-web-service/templates/certificate.yaml
@@ -5,6 +5,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: {{ $certName }}
+  labels: {{- include "bandstand-web-service.labels" $ | nindent 4 }}
 spec:
   commonName: {{ . }}
   dnsNames:

--- a/charts/bandstand-web-service/templates/extsecrets.yaml
+++ b/charts/bandstand-web-service/templates/extsecrets.yaml
@@ -5,6 +5,7 @@ apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: {{ $secretName }}
+  labels: {{- include "bandstand-web-service.labels" $ | nindent 4 }}
   annotations:
     force-sync: '{{ now | unixEpoch }}'
 spec:
@@ -22,6 +23,6 @@ spec:
         {{- if .upperCaseKeys }}
         - transform:
             template: {{`'{{ .value | upper }}'`}}
-        {{- end}}
+        {{- end }}
 ---
 {{- end }}

--- a/charts/bandstand-web-service/templates/scaled-object.yaml
+++ b/charts/bandstand-web-service/templates/scaled-object.yaml
@@ -7,6 +7,7 @@ apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
 metadata:
   name: {{ $relName }}
+  labels: {{- include "bandstand-web-service.labels" . | nindent 4 }}
 spec:
   cooldownPeriod: {{ (.Values.advancedScaling.cooldown) | default 30 }}
   maxReplicaCount: {{ (.Values.advancedScaling.maxReplicas) | default 3 }}

--- a/charts/bandstand-web-service/templates/service.yaml
+++ b/charts/bandstand-web-service/templates/service.yaml
@@ -6,6 +6,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ $relName }}
+  labels: {{- include "bandstand-web-service.labels" . | nindent 4 }}
 spec:
   selector: {{- include "bandstand-web-service.selectorLabels" . | nindent 4 }}
   ports:

--- a/charts/bandstand-web-service/templates/tests/extsecrets.yaml
+++ b/charts/bandstand-web-service/templates/tests/extsecrets.yaml
@@ -22,6 +22,6 @@ spec:
         {{- if .upperCaseKeys }}
         - transform:
             template: {{`'{{ .value | upper }}'`}}
-        {{- end}}
+        {{- end }}
 ---
 {{- end }}


### PR DESCRIPTION
## Description
Spotted some resources don't have all the common labels applied, especially external secrets. That means they don't appear in backstage as it relies on label selectors (and they aren't accessible to stagehand)

## Checklist

- [ ] I have updated the affected chart versions
- [ ] I have updated the documentation accordingly and documented any new attributes
- [ ] I have added new tests and incorporated them into the build
