### PR TITLE
DEP-2652 Block disruption of test runs and triggered jobs

### DIFF
--- a/charts/bandstand-test-runner/Chart.yaml
+++ b/charts/bandstand-test-runner/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bandstand-test-runner
-version: 2.6.2
+version: 2.6.3
 description: Application for running standalone test pod
 type: application
 maintainers:

--- a/charts/bandstand-test-runner/templates/tests/pod.yaml
+++ b/charts/bandstand-test-runner/templates/tests/pod.yaml
@@ -23,6 +23,7 @@ metadata:
     "polaris.fairwinds.com/readinessProbeMissing-exempt": "true"
     "polaris.fairwinds.com/livenessProbeMissing-exempt": "true"
     "linkerd.io/inject": disabled
+    "karpenter.sh/do-not-disrupt": "true"
     "botkube.io/disable": "true"
 spec:
   serviceAccountName: {{ $.Release.Name }}

--- a/charts/bandstand-triggered-job/Chart.yaml
+++ b/charts/bandstand-triggered-job/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bandstand-triggered-job
-version: 1.8.1
+version: 1.8.2
 description: Application chart for a job triggered from SQS
 type: application
 maintainers:

--- a/charts/bandstand-triggered-job/templates/scaledjob.yaml
+++ b/charts/bandstand-triggered-job/templates/scaledjob.yaml
@@ -19,6 +19,7 @@ spec:
       metadata:
         annotations:
           "linkerd.io/inject": disabled
+          "karpenter.sh/do-not-disrupt": "true"
         labels: {{- include "bandstand-triggered-job.labels" . | nindent 10 }}
       spec:
         serviceAccountName: {{ .Release.Name }}


### PR DESCRIPTION
## Description
Add do not disrupt annotation to triggered job and test runner pods

## Checklist

- [ ] I have updated the affected chart versions
- [ ] I have updated the documentation accordingly and documented any new attributes
- [ ] I have added new tests and incorporated them into the build
