### PR TITLE
DEP-2631 Use v1 external secrets api

### DIFF
--- a/charts/bandstand-confluent-connect/Chart.yaml
+++ b/charts/bandstand-confluent-connect/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bandstand-confluent-connect
-version: 1.2.11
+version: 1.2.12
 description: Chart for deploying confluent connect clusters and connectors
 type: application
 sources:

--- a/charts/bandstand-confluent-connect/templates/external-secret-connect.yaml
+++ b/charts/bandstand-confluent-connect/templates/external-secret-connect.yaml
@@ -2,7 +2,7 @@
 {{- if .Values.nameSuffix }}
 {{- $relName = print .Release.Name "-" .Values.nameSuffix }}
 {{- end }}
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: {{ $relName }}

--- a/charts/bandstand-cron-job/Chart.yaml
+++ b/charts/bandstand-cron-job/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bandstand-cron-job
-version: 4.7.0
+version: 4.7.1
 description: Application chart for a simple cron job
 type: application
 maintainers:

--- a/charts/bandstand-cron-job/templates/extsecrets.yaml
+++ b/charts/bandstand-cron-job/templates/extsecrets.yaml
@@ -1,7 +1,7 @@
 {{- range .Values.secrets }}
 {{- $secretHash := sha256sum .secret | substr 0 6 }}
 {{- $secretName := list $.Release.Name $.Values.nameSuffix .name $secretHash | join "-" }}
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: {{ $secretName }}

--- a/charts/bandstand-headless-service/Chart.yaml
+++ b/charts/bandstand-headless-service/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bandstand-headless-service
-version: 3.9.0
+version: 3.9.1
 description: Chart for a standalone (non-web) service
 type: application
 maintainers:

--- a/charts/bandstand-headless-service/templates/extsecrets.yaml
+++ b/charts/bandstand-headless-service/templates/extsecrets.yaml
@@ -1,7 +1,7 @@
 {{- range .Values.secrets }}
 {{- $secretHash := sha256sum .secret | substr 0 6 }}
 {{- $secretName := list $.Release.Name $.Values.nameSuffix .name $secretHash | join "-" }}
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: {{ $secretName }}

--- a/charts/bandstand-job/Chart.yaml
+++ b/charts/bandstand-job/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bandstand-job
-version: 1.5.0
+version: 1.5.1
 description: Application chart for a simple job starting immediately after deployment
 type: application
 maintainers:

--- a/charts/bandstand-job/templates/extsecrets.yaml
+++ b/charts/bandstand-job/templates/extsecrets.yaml
@@ -1,7 +1,7 @@
 {{- range .Values.secrets }}
 {{- $secretHash := sha256sum .secret | substr 0 6 }}
 {{- $secretName := list $.Release.Name $.Values.nameSuffix .name $secretHash | join "-" }}
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: {{ $secretName }}

--- a/charts/bandstand-test-runner/Chart.yaml
+++ b/charts/bandstand-test-runner/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bandstand-test-runner
-version: 2.6.3
+version: 2.6.4
 description: Application for running standalone test pod
 type: application
 maintainers:

--- a/charts/bandstand-test-runner/templates/extsecrets.yaml
+++ b/charts/bandstand-test-runner/templates/extsecrets.yaml
@@ -1,7 +1,7 @@
 {{- range .Values.secrets }}
 {{- $secretHash := sha256sum .secret | substr 0 6 }}
 {{- $secretName := list $.Release.Name .name $secretHash | join "-" }}
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: {{ $secretName }}

--- a/charts/bandstand-triggered-job/Chart.yaml
+++ b/charts/bandstand-triggered-job/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bandstand-triggered-job
-version: 1.9.0
+version: 1.9.1
 description: Application chart for a job triggered from SQS
 type: application
 maintainers:

--- a/charts/bandstand-triggered-job/templates/extsecrets.yaml
+++ b/charts/bandstand-triggered-job/templates/extsecrets.yaml
@@ -1,7 +1,7 @@
 {{- range .Values.secrets }}
 {{- $secretHash := sha256sum .secret | substr 0 6 }}
 {{- $secretName := list $.Release.Name $.Values.nameSuffix .name $secretHash | join "-" }}
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: {{ $secretName }}

--- a/charts/bandstand-web-service/Chart.yaml
+++ b/charts/bandstand-web-service/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bandstand-web-service
-version: 4.13.0
+version: 4.13.1
 description: Application chart for a web service
 type: application
 maintainers:

--- a/charts/bandstand-web-service/templates/extsecrets.yaml
+++ b/charts/bandstand-web-service/templates/extsecrets.yaml
@@ -1,7 +1,7 @@
 {{- range .Values.secrets }}
 {{- $secretHash := sha256sum .secret | substr 0 6 }}
 {{- $secretName := list $.Release.Name $.Values.nameSuffix .name $secretHash | join "-" }}
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: {{ $secretName }}

--- a/charts/bandstand-web-service/templates/tests/extsecrets.yaml
+++ b/charts/bandstand-web-service/templates/tests/extsecrets.yaml
@@ -1,7 +1,7 @@
 {{- range (.Values.test).secrets }}
 {{- $secretHash := sha256sum .secret | substr 0 6 }}
 {{- $secretName := list $.Release.Name $.Values.nameSuffix .name "acceptance-test" $secretHash | join "-" }}
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: {{ $secretName }}


### PR DESCRIPTION
## Description
Upgrade all charts to use the v1 external secrets api

## Checklist

- [x] I have updated the affected chart versions
- [ ] I have updated the documentation accordingly and documented any new attributes
- [ ] I have added new tests and incorporated them into the build
