### PR TITLE
DEP-2726 Use linkerd native sidecar for Jobs

### DIFF
--- a/charts/bandstand-cron-job/Chart.yaml
+++ b/charts/bandstand-cron-job/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bandstand-cron-job
-version: 4.8.1
+version: 4.9.0
 description: Application chart for a simple cron job
 type: application
 maintainers:

--- a/charts/bandstand-cron-job/templates/cronjob.yaml
+++ b/charts/bandstand-cron-job/templates/cronjob.yaml
@@ -16,7 +16,7 @@ spec:
       template:
         metadata:
           annotations:
-            "linkerd.io/inject": disabled
+            "config.alpha.linkerd.io/proxy-enable-native-sidecar": "true"
             "karpenter.sh/do-not-disrupt": "true"
           labels: {{- include "bandstand-cron-job.labels" . | nindent 12 }}
         spec:

--- a/charts/bandstand-job/Chart.yaml
+++ b/charts/bandstand-job/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bandstand-job
-version: 1.6.1
+version: 1.7.0
 description: Application chart for a simple job starting immediately after deployment
 type: application
 maintainers:

--- a/charts/bandstand-job/templates/job.yaml
+++ b/charts/bandstand-job/templates/job.yaml
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       annotations:
-        "linkerd.io/inject": disabled
+        "config.alpha.linkerd.io/proxy-enable-native-sidecar": "true"
         "karpenter.sh/do-not-disrupt": "true"
       labels: {{- include "bandstand-job.labels" . | nindent 8 }}
     spec:

--- a/charts/bandstand-test-runner/Chart.yaml
+++ b/charts/bandstand-test-runner/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bandstand-test-runner
-version: 2.7.1
+version: 2.8.0
 description: Application for running standalone test pod
 type: application
 maintainers:

--- a/charts/bandstand-test-runner/templates/tests/pod.yaml
+++ b/charts/bandstand-test-runner/templates/tests/pod.yaml
@@ -21,7 +21,7 @@ metadata:
     "helm.sh/hook-delete-policy": before-hook-creation
     "polaris.fairwinds.com/readinessProbeMissing-exempt": "true"
     "polaris.fairwinds.com/livenessProbeMissing-exempt": "true"
-    "linkerd.io/inject": disabled
+    "config.alpha.linkerd.io/proxy-enable-native-sidecar": "true"
     "karpenter.sh/do-not-disrupt": "true"
     "botkube.io/disable": "true"
 spec:

--- a/charts/bandstand-triggered-job/Chart.yaml
+++ b/charts/bandstand-triggered-job/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bandstand-triggered-job
-version: 1.10.1
+version: 1.11.0
 description: Application chart for a job triggered from SQS
 type: application
 maintainers:

--- a/charts/bandstand-triggered-job/templates/scaledjob.yaml
+++ b/charts/bandstand-triggered-job/templates/scaledjob.yaml
@@ -18,7 +18,7 @@ spec:
     template:
       metadata:
         annotations:
-          "linkerd.io/inject": disabled
+          "config.alpha.linkerd.io/proxy-enable-native-sidecar": "true"
           "karpenter.sh/do-not-disrupt": "true"
         labels: {{- include "bandstand-triggered-job.labels" . | nindent 10 }}
       spec:


### PR DESCRIPTION
## Description
Enables linkerd native sidecar proxy injection for Job pods

## Checklist

- [ ] I have updated the affected chart versions
- [ ] I have updated the documentation accordingly and documented any new attributes
- [ ] I have added new tests and incorporated them into the build
