### PR TITLE
DEP-2114 Default reloader to being enabled (as per chart docs)

### DIFF
--- a/charts/bandstand-headless-service/Chart.yaml
+++ b/charts/bandstand-headless-service/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bandstand-headless-service
-version: 3.12.3
+version: 3.12.4
 description: Chart for a standalone (non-web) service
 type: application
 maintainers:

--- a/charts/bandstand-headless-service/templates/deployment.yaml
+++ b/charts/bandstand-headless-service/templates/deployment.yaml
@@ -12,7 +12,7 @@ spec:
       annotations:
         rollme: {{ randAlphaNum 5 | quote }}
         config.alpha.linkerd.io/proxy-enable-native-sidecar: 'true'
-        {{- if (.Values.reloader).enabled }}
+        {{- if ne (.Values.reloader).enabled false }}
         reloader.stakater.com/auto: "true"
         {{- end }}
       labels: {{- include "bandstand-headless-service.labels" . | nindent 8 }}

--- a/charts/bandstand-web-service/Chart.yaml
+++ b/charts/bandstand-web-service/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bandstand-web-service
-version: 4.18.3
+version: 4.18.4
 description: Application chart for a web service
 type: application
 maintainers:

--- a/charts/bandstand-web-service/templates/deployment.yaml
+++ b/charts/bandstand-web-service/templates/deployment.yaml
@@ -16,7 +16,7 @@ spec:
         config.linkerd.io/proxy-memory-request: {{ .Values.resources.requests.linkerd.memory }}
         {{- end }}
         config.alpha.linkerd.io/proxy-enable-native-sidecar: 'true'
-        {{- if (.Values.reloader).enabled }}
+        {{- if ne (.Values.reloader).enabled false }}
         reloader.stakater.com/auto: "true"
         {{- end }}
       labels: {{- include "bandstand-web-service.labels" . | nindent 8 }}

--- a/test-charts/headless-service/reloader/values.yaml
+++ b/test-charts/headless-service/reloader/values.yaml
@@ -7,4 +7,4 @@ bandstand-headless-service:
     enabled: true
 
   reloader:
-    enabled: true
+    enabled: false

--- a/test-charts/web-service/reloader/values.yaml
+++ b/test-charts/web-service/reloader/values.yaml
@@ -7,5 +7,4 @@ bandstand-web-service:
     enabled: true
 
   reloader:
-    enabled: true
-
+    enabled: false


### PR DESCRIPTION
## Description
Chart docs say reloader is on by default, but it is opt in. I'm changing the behaviour to match our docs.
## Checklist

- [x] I have updated the affected chart versions
- [ ] I have updated the documentation accordingly and documented any new attributes
- [x] I have added new tests and incorporated them into the build
