### PR TITLE
Dep 3020 update for traefik

### DIFF
--- a/charts/bandstand-confluent-connect/Chart.yaml
+++ b/charts/bandstand-confluent-connect/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bandstand-confluent-connect
-version: 1.3.1
+version: 1.4.0
 description: Chart for deploying confluent connect clusters and connectors
 type: application
 sources:

--- a/charts/bandstand-confluent-connect/templates/ingress.yaml
+++ b/charts/bandstand-confluent-connect/templates/ingress.yaml
@@ -38,7 +38,7 @@ spec:
             pathType: Prefix
             backend:
               service:
-                name: {{ $relName }}
+                name: {{ $relName }}-proxy
                 port:
                   number: {{ .Values.ingress.port }}
     {{- range $.Values.additionalDomains }}

--- a/charts/bandstand-confluent-connect/templates/service.yaml
+++ b/charts/bandstand-confluent-connect/templates/service.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.ingress.enabled }}
+{{- $relName := .Release.Name -}}
+{{- if .Values.nameSuffix }}
+  {{- $relName = print .Release.Name "-" .Values.nameSuffix }}
+{{- end }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $relName }}-proxy
+  labels: {{- include "bandstand-confluent-connect.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  selector:
+    app: {{ $relName }}
+    clusterId: {{ .Release.Namespace }}
+    confluent-platform: "true"
+    type: {{ $relName }}
+  ports:
+    - port: {{ .Values.ingress.port }}
+      targetPort: {{ .Values.ingress.port }}
+      protocol: TCP
+{{- end }}


### PR DESCRIPTION
## Description
Fix headless service routing for Confluent Connect Ingresses

Traefik's kubernetesIngressNginx provider resolves Ingress backend service ClusterIPs literally. For Confluent Connect clusters, the Kubernetes operator creates headless services (clusterIP: None), which causes Traefik to route requests to http://None:<port> → 502.

Root cause: nginx.ingress.kubernetes.io/service-upstream: "true" (set in the Ingress annotation) instructs nginx to use DNS-based upstream resolution, which correctly resolves headless service DNS to pod IPs. Traefik ignores this annotation and uses the ClusterIP directly.

Fix: When ingress.enabled: true, a standard ClusterIP service (<relName>-proxy) is now created alongside the Ingress. This service uses the same pod selector labels as the Confluent operator headless service (app, clusterId, confluent-platform, type), giving Traefik a real ClusterIP to route to. The Ingress backend is updated to point to this wrapper service.

Affected services (all using this chart as a dependency):

royid-connect-svc (kobalt, all envs)
royalty-cdc-s3-sink (amra, all envs)
royalty-payment-cdc-s3-sink (amra, all envs)
After releasing 1.4.0, dependent releases will need to be redeployed to create the ClusterIP wrapper service in each namespace.

## Checklist

- [ ] I have updated the affected chart versions
- [ ] I have updated the documentation accordingly and documented any new attributes
- [ ] I have added new tests and incorporated them into the build
