### PR TITLE
DEP-3085 fix bandstand-web-service PVC multi-replica and restart issues

### DIFF
--- a/charts/bandstand-headless-service/Chart.yaml
+++ b/charts/bandstand-headless-service/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bandstand-headless-service
-version: 3.12.5
+version: 3.13.0
 description: Chart for a standalone (non-web) service
 type: application
 maintainers:

--- a/charts/bandstand-headless-service/templates/NOTES.txt
+++ b/charts/bandstand-headless-service/templates/NOTES.txt
@@ -1,1 +1,5 @@
 You're installing this chart in aws account {{ .Values.global.aws.account }}.
+{{- if (.Values.volume).persistent }}
+
+WARNING: volume.persistent is set. The deployment uses the Recreate strategy — pods will have downtime during rollouts while the EBS volume is detached and reattached.
+{{- end }}

--- a/charts/bandstand-headless-service/templates/deployment.yaml
+++ b/charts/bandstand-headless-service/templates/deployment.yaml
@@ -13,9 +13,6 @@ metadata:
   name: {{ $relName }}
   annotations:
     deployment.reloader.stakater.com/pause-period: 10s
-    {{- if (.Values.volume).persistent }}
-    bandstand.ktech.com/persistent-volume-notice: "Persistent EBS volume in use. Recreate strategy is active — pods will have downtime during rollouts."
-    {{- end }}
   labels: {{- include "bandstand-headless-service.labels" . | nindent 4 }}
 spec:
   {{- if (.Values.volume).persistent }}

--- a/charts/bandstand-headless-service/templates/deployment.yaml
+++ b/charts/bandstand-headless-service/templates/deployment.yaml
@@ -1,12 +1,27 @@
 {{- $relName := include "bandstand-headless-service.fullname" $ -}}
+{{- if (.Values.volume).persistent }}
+{{- if and (ne ((.Values.hpa).enabled) false) (gt (int ((.Values.hpa).maxReplicas | default 3)) 1) }}
+{{- fail "volume.persistent requires a single replica. Set hpa.maxReplicas=1 or disable the HPA (hpa.enabled=false). EBS volumes (ReadWriteOncePod) cannot be shared across pods." }}
+{{- end }}
+{{- if and ((.Values.advancedScaling).enabled) (gt (int ((.Values.advancedScaling).maxReplicas | default 3)) 1) }}
+{{- fail "volume.persistent requires a single replica. Set advancedScaling.maxReplicas=1. EBS volumes (ReadWriteOncePod) cannot be shared across pods." }}
+{{- end }}
+{{- end }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ $relName }}
   annotations:
     deployment.reloader.stakater.com/pause-period: 10s
+    {{- if (.Values.volume).persistent }}
+    bandstand.ktech.com/persistent-volume-notice: "Persistent EBS volume in use. Recreate strategy is active — pods will have downtime during rollouts."
+    {{- end }}
   labels: {{- include "bandstand-headless-service.labels" . | nindent 4 }}
 spec:
+  {{- if (.Values.volume).persistent }}
+  strategy:
+    type: Recreate
+  {{- end }}
   selector:
     matchLabels: {{- include "bandstand-headless-service.selectorLabels" . | nindent 6 }}
   template:

--- a/charts/bandstand-headless-service/templates/pvc.yaml
+++ b/charts/bandstand-headless-service/templates/pvc.yaml
@@ -7,7 +7,7 @@ metadata:
   labels: {{- include "bandstand-headless-service.labels" . | nindent 4 }}
 spec:
   accessModes:
-    - ReadWriteOnce
+    - ReadWriteOncePod
   storageClassName: {{ .Values.volume.storageClass | default "general-storage" }}
   resources:
     requests:

--- a/charts/bandstand-web-service/Chart.yaml
+++ b/charts/bandstand-web-service/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bandstand-web-service
-version: 4.19.0
+version: 4.20.0
 description: Application chart for a web service
 type: application
 maintainers:

--- a/charts/bandstand-web-service/templates/NOTES.txt
+++ b/charts/bandstand-web-service/templates/NOTES.txt
@@ -1,1 +1,5 @@
 You're installing this chart in aws account {{ .Values.global.aws.account }}.
+{{- if (.Values.volume).persistent }}
+
+WARNING: volume.persistent is set. The deployment uses the Recreate strategy — pods will have downtime during rollouts while the EBS volume is detached and reattached.
+{{- end }}

--- a/charts/bandstand-web-service/templates/deployment.yaml
+++ b/charts/bandstand-web-service/templates/deployment.yaml
@@ -13,9 +13,6 @@ metadata:
   name: {{ $relName }}
   annotations:
     deployment.reloader.stakater.com/pause-period: 10s
-    {{- if (.Values.volume).persistent }}
-    bandstand.ktech.com/persistent-volume-notice: "Persistent EBS volume in use. Recreate strategy is active — pods will have downtime during rollouts."
-    {{- end }}
   labels: {{- include "bandstand-web-service.labels" . | nindent 4 }}
 spec:
   {{- if (.Values.volume).persistent }}

--- a/charts/bandstand-web-service/templates/deployment.yaml
+++ b/charts/bandstand-web-service/templates/deployment.yaml
@@ -1,12 +1,27 @@
 {{- $relName := include "bandstand-web-service.fullname" $ -}}
+{{- if (.Values.volume).persistent }}
+{{- if and (ne ((.Values.hpa).enabled) false) (gt (int ((.Values.hpa).maxReplicas | default 3)) 1) }}
+{{- fail "volume.persistent requires a single replica. Set hpa.maxReplicas=1 or disable the HPA (hpa.enabled=false). EBS volumes (ReadWriteOncePod) cannot be shared across pods." }}
+{{- end }}
+{{- if and ((.Values.advancedScaling).enabled) (gt (int ((.Values.advancedScaling).maxReplicas | default 3)) 1) }}
+{{- fail "volume.persistent requires a single replica. Set advancedScaling.maxReplicas=1. EBS volumes (ReadWriteOncePod) cannot be shared across pods." }}
+{{- end }}
+{{- end }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ $relName }}
   annotations:
     deployment.reloader.stakater.com/pause-period: 10s
+    {{- if (.Values.volume).persistent }}
+    bandstand.ktech.com/persistent-volume-notice: "Persistent EBS volume in use. Recreate strategy is active — pods will have downtime during rollouts."
+    {{- end }}
   labels: {{- include "bandstand-web-service.labels" . | nindent 4 }}
 spec:
+  {{- if (.Values.volume).persistent }}
+  strategy:
+    type: Recreate
+  {{- end }}
   selector:
     matchLabels: {{- include "bandstand-web-service.selectorLabels" . | nindent 6 }}
   template:

--- a/charts/bandstand-web-service/templates/pvc.yaml
+++ b/charts/bandstand-web-service/templates/pvc.yaml
@@ -7,7 +7,7 @@ metadata:
   labels: {{- include "bandstand-web-service.labels" . | nindent 4 }}
 spec:
   accessModes:
-    - ReadWriteOnce
+    - ReadWriteOncePod
   storageClassName: {{ .Values.volume.storageClass | default "general-storage" }}
   resources:
     requests:

--- a/test-charts/headless-service/with-persistent-volume/values.yaml
+++ b/test-charts/headless-service/with-persistent-volume/values.yaml
@@ -2,5 +2,8 @@ bandstand-headless-service:
   owner: ktech-developer-platform
   env: test
   business: ktech
+  hpa:
+    maxReplicas: 1
+
   volume:
     persistent: 1G

--- a/test-charts/web-service/with-persistent-volume/values.yaml
+++ b/test-charts/web-service/with-persistent-volume/values.yaml
@@ -5,5 +5,8 @@ bandstand-web-service:
 
   ingress:
     enabled: false
+  hpa:
+    maxReplicas: 1
+
   volume:
     persistent: 8G


### PR DESCRIPTION
## Summary

Fixes issues where enabling `volume.persistent` on `bandstand-web-service` would break with multiple replicas or fail to restart cleanly. EBS volumes only support `ReadWriteOnce`/`ReadWriteOncePod` (single attachment), so the previous setup silently produced broken deployments.

- **Validation**: `helm template`/`helm upgrade` now fails with a clear error if `volume.persistent` is set alongside `hpa.maxReplicas > 1` or `advancedScaling.maxReplicas > 1`
- **Recreate strategy**: Deployment switches to `strategy: type: Recreate` when `volume.persistent` is set, ensuring the old pod fully detaches the EBS volume before the replacement starts (fixes rolling update deadlock)
- **ReadWriteOncePod**: PVC access mode changed from `ReadWriteOnce` to `ReadWriteOncePod`, scoping the volume to a single pod at the cluster level rather than just a single node
- **Observability**: `NOTES.txt` warning surface the Recreate strategy to operators


Closes DEP-3085

🤖 Generated with [Claude Code](https://claude.com/claude-code)